### PR TITLE
Adding the ability to cancel sending logs to Logstash

### DIFF
--- a/Example/JustLog/Info.plist
+++ b/Example/JustLog/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/JustLog.podspec
+++ b/JustLog.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'JustLog'
-  s.version          = '1.1.1'
+  s.version          = '1.1.2'
   s.summary          = 'JustLog brings logging on iOS to the next level. It supports console, file and remote Logstash logging via TCP socket with no effort.'
 
   s.description      = "<<-DESC

--- a/JustLog/Classes/AsyncSocketManager.swift
+++ b/JustLog/Classes/AsyncSocketManager.swift
@@ -12,6 +12,7 @@ import CocoaAsyncSocket
 protocol AsyncSocketManagerDelegate: class {
     func socketDidSecure(_ socket: GCDAsyncSocket)
     func socket(_ socket: GCDAsyncSocket, didWriteDataWithTag tag: Int)
+    func socket(_ socket: GCDAsyncSocket, didDisconnectWithError error: Error?)
 }
 
 class AsyncSocketManager: NSObject {
@@ -62,7 +63,7 @@ class AsyncSocketManager: NSObject {
     }
 }
 
-//MARK: - Connection Management
+// MARK: - Connection Management
 
 extension AsyncSocketManager {
     
@@ -93,7 +94,7 @@ extension AsyncSocketManager {
     }
 }
 
-//MARK: - Socket Attributes
+// MARK: - Socket Attributes
 
 extension AsyncSocketManager {
     
@@ -106,7 +107,7 @@ extension AsyncSocketManager {
     }
 }
 
-//MARK: - Swift Delegate wrapper
+// MARK: - Swift Delegate wrapper
 
 extension AsyncSocketManager: GCDAsyncSocketDelegate {
 
@@ -139,5 +140,6 @@ extension AsyncSocketManager: GCDAsyncSocketDelegate {
                 print("🔌 <AsyncSocket>, disconnected!")
             }
         }
+        self.delegate?.socket(sock, didDisconnectWithError: err)
     }
 }

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -92,6 +92,12 @@ public final class Logger: NSObject {
         }
     }
     
+    public func cancelSending() {
+        if enableLogstashLogging {
+            logstash.cancelSending()
+        }
+    }
+    
     public func verbose(_ message: String, error: NSError? = nil, userInfo: [String : Any]? = nil, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
         let updatedUserInfo = [logTypeKey: "verbose"].merged(with: userInfo ?? [String : String]())
         let logMessage = self.logMessage(message, error: error, userInfo: updatedUserInfo, file, function, line)

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -86,7 +86,7 @@ public final class Logger: NSObject {
         dispatchTimer = Timer.scheduledTimer(timeInterval: 5, target: self, selector: #selector(scheduledForceSend(_:)), userInfo: nil, repeats: true)
     }
     
-    public func forceSend(_ completionHandler: @escaping () -> Void = {}) {
+    public func forceSend(_ completionHandler: @escaping (_ error: Error?) -> Void = {_ in }) {
         if enableLogstashLogging {
             logstash.forceSend(completionHandler)
         }

--- a/JustLog/Classes/LogstashDestination.swift
+++ b/JustLog/Classes/LogstashDestination.swift
@@ -35,10 +35,16 @@ public class LogstashDestination: BaseDestination  {
     }
     
     deinit {
+        cancelSending()
+    }
+    
+    public func cancelSending() {
         self.logDispatchQueue.cancelAllOperations()
         self.socketManager.disconnect()
     }
     
+    // MARK: - Log dispatching
+
     override public func send(_ level: SwiftyBeaver.Level, msg: String, thread: String,
                               file: String, function: String, line: Int) -> String? {
         
@@ -52,13 +58,7 @@ public class LogstashDestination: BaseDestination  {
         
         return nil
     }
-    
-}
 
-//MARK:- Log dispatching
-
-extension LogstashDestination {
-    
     public func forceSend(_ completionHandler: @escaping () -> Void  = {}) {
         
         self.completionHandler = completionHandler
@@ -110,7 +110,7 @@ extension LogstashDestination {
     
 }
 
-//MARK: - GCDAsyncSocketManager Delegate
+// MARK: - GCDAsyncSocketManager Delegate
 
 extension LogstashDestination: AsyncSocketManagerDelegate {
     

--- a/JustLog/Classes/LogstashDestination.swift
+++ b/JustLog/Classes/LogstashDestination.swift
@@ -15,7 +15,7 @@ public class LogstashDestination: BaseDestination  {
     public var logzioToken: String?
     
     var logsToShip = [Int : [String : Any]]()
-    fileprivate var completionHandler: (() -> Void)?
+    fileprivate var completionHandler: ((_ error: Error?) -> Void)?
     private let logzioTokenKey = "token"
     
     var logActivity: Bool = false
@@ -59,11 +59,14 @@ public class LogstashDestination: BaseDestination  {
         return nil
     }
 
-    public func forceSend(_ completionHandler: @escaping () -> Void  = {}) {
+    public func forceSend(_ completionHandler: @escaping (_ error: Error?) -> Void  = {_ in }) {
         
+        if self.logsToShip.count == 0 || self.socketManager.isConnected() {
+            completionHandler(nil)
+            return
+        }
+
         self.completionHandler = completionHandler
-        
-        if self.logsToShip.count == 0 || self.socketManager.isConnected() { return }
         
         logDispatchQueue.addOperation { [weak self] in
             self?.socketManager.send()
@@ -120,7 +123,7 @@ extension LogstashDestination: AsyncSocketManagerDelegate {
         }
         
         if let completionHandler = self.completionHandler {
-            completionHandler()
+            completionHandler(nil)
         }
         
         completionHandler = nil
@@ -130,4 +133,13 @@ extension LogstashDestination: AsyncSocketManagerDelegate {
         self.writeLogs()
     }
     
+    func socket(_ socket: GCDAsyncSocket, didDisconnectWithError error: Error?) {
+        
+        if let completionHandler = self.completionHandler {
+            completionHandler(error)
+        }
+        
+        completionHandler = nil
+    }
 }
+ 


### PR DESCRIPTION
This is required so sending can be cancelled, as in the case where sending may be orchestrated by a background task (in which we might want to cancel sending in the background task's expiration handler)

This also ensures the completion handler on forceSend to logstash is called, also that disconnected socket errors are reported back to callers. 