### PR TITLE
Updated some of the types on the Logging interface (and Logger)

### DIFF
--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -101,41 +101,51 @@ public final class Logger: NSObject {
 
 extension Logger: Logging {
     
-    public func verbose(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: Int) {
+    public func verbose(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: StaticString, _ function: StaticString, _ line: UInt) {
+        let file = String(describing: file)
+        let function = String(describing: function)
         let updatedUserInfo = [logTypeKey: "verbose"].merged(with: userInfo ?? [String : String]())
         let logMessage = self.logMessage(message, error: error, userInfo: updatedUserInfo, file, function, line)
-        internalLogger.verbose(logMessage, file, function, line: line)
+        internalLogger.verbose(logMessage, file, function, line: Int(line))
     }
     
-    public func debug(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: Int) {
+    public func debug(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: StaticString, _ function: StaticString, _ line: UInt) {
+        let file = String(describing: file)
+        let function = String(describing: function)
         let updatedUserInfo = [logTypeKey: "debug"].merged(with: userInfo ?? [String : String]())
         let logMessage = self.logMessage(message, error: error, userInfo: updatedUserInfo, file, function, line)
-        internalLogger.debug(logMessage, file, function, line: line)
+        internalLogger.debug(logMessage, file, function, line: Int(line))
     }
     
-    public func info(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: Int) {
+    public func info(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: StaticString, _ function: StaticString, _ line: UInt) {
+        let file = String(describing: file)
+        let function = String(describing: function)
         let updatedUserInfo = [logTypeKey: "info"].merged(with: userInfo ?? [String : String]())
         let logMessage = self.logMessage(message, error: error, userInfo: updatedUserInfo, file, function, line)
-        internalLogger.info(logMessage, file, function, line: line)
+        internalLogger.info(logMessage, file, function, line: Int(line))
     }
     
-    public func warning(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: Int) {
+    public func warning(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: StaticString, _ function: StaticString, _ line: UInt) {
+        let file = String(describing: file)
+        let function = String(describing: function)
         let updatedUserInfo = [logTypeKey: "warning"].merged(with: userInfo ?? [String : String]())
         let logMessage = self.logMessage(message, error: error, userInfo: updatedUserInfo, file, function, line)
-        internalLogger.warning(logMessage, file, function, line: line)
+        internalLogger.warning(logMessage, file, function, line: Int(line))
     }
     
-    public func error(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: Int) {
+    public func error(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: StaticString, _ function: StaticString, _ line: UInt) {
+        let file = String(describing: file)
+        let function = String(describing: function)
         let updatedUserInfo = [logTypeKey: "error"].merged(with: userInfo ?? [String : Any]())
         let logMessage = self.logMessage(message, error: error, userInfo: updatedUserInfo, file, function, line)
-        internalLogger.error(logMessage, file, function, line: line)
+        internalLogger.error(logMessage, file, function, line: Int(line))
     }
     
 }
 
 extension Logger {
     
-    fileprivate func logMessage(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: Int) -> String {
+    fileprivate func logMessage(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: UInt) -> String {
     
         let messageConst = "message"
         let userInfoConst = "userInfo"

--- a/JustLog/Classes/Logging.swift
+++ b/JustLog/Classes/Logging.swift
@@ -10,15 +10,15 @@ import UIKit
 
 public protocol Logging {
     
-    func verbose(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: Int)
+    func verbose(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: StaticString, _ function: StaticString, _ line: UInt)
     
-    func debug(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: Int)
+    func debug(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: StaticString, _ function: StaticString, _ line: UInt)
     
-    func info(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: Int)
+    func info(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: StaticString, _ function: StaticString, _ line: UInt)
     
-    func warning(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: Int)
+    func warning(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: StaticString, _ function: StaticString, _ line: UInt)
     
-    func error(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: Int)
+    func error(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: StaticString, _ function: StaticString, _ line: UInt)
     
 }
 
@@ -27,23 +27,23 @@ public protocol Logging {
 
 extension Logging {
     
-    public func verbose(_ message: String, error: NSError? = nil, userInfo: [String : Any]? = nil, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
+    public func verbose(_ message: String, error: NSError? = nil, userInfo: [String : Any]? = nil, _ file: StaticString = #file, _ function: StaticString = #function, _ line: UInt = #line) {
         verbose(message, error: error, userInfo: userInfo, file, function, line)
     }
     
-    public func debug(_ message: String, error: NSError? = nil, userInfo: [String : Any]? = nil, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
+    public func debug(_ message: String, error: NSError? = nil, userInfo: [String : Any]? = nil, _ file: StaticString = #file, _ function: StaticString = #function, _ line: UInt = #line) {
         debug(message, error: error, userInfo: userInfo, file, function, line)
     }
     
-    public func info(_ message: String, error: NSError? = nil, userInfo: [String : Any]? = nil, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
+    public func info(_ message: String, error: NSError? = nil, userInfo: [String : Any]? = nil, _ file: StaticString = #file, _ function: StaticString = #function, _ line: UInt = #line) {
         info(message, error: error, userInfo: userInfo, file, function, line)
     }
     
-    public func warning(_ message: String, error: NSError? = nil, userInfo: [String : Any]? = nil, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
+    public func warning(_ message: String, error: NSError? = nil, userInfo: [String : Any]? = nil, _ file: StaticString = #file, _ function: StaticString = #function, _ line: UInt = #line) {
         warning(message, error: error, userInfo: userInfo, file, function, line)
     }
     
-    public func error(_ message: String, error: NSError? = nil, userInfo: [String : Any]? = nil, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
+    public func error(_ message: String, error: NSError? = nil, userInfo: [String : Any]? = nil, _ file: StaticString = #file, _ function: StaticString = #function, _ line: UInt = #line) {
         self.error(message, error: error, userInfo: userInfo, file, function, line)
     }
     


### PR DESCRIPTION
`file` and `function` have been changed from String to StaticString, this is more efficient and allows the interface to be used in conjunction CocoaLumberjack which uses StaticString (because there’s no way to go from String to StaticString). I also updated `line` to use UInt rather than Int since this is more specific.