### PR TITLE
Fix downcast to String warning

### DIFF
--- a/JustLog/Extensions/Data+Representation.swift
+++ b/JustLog/Extensions/Data+Representation.swift
@@ -11,7 +11,7 @@ import Foundation
 extension Data {
     
     func stringRepresentation() -> String {
-        let retVal = NSString(data: self, encoding: String.Encoding.utf8.rawValue) as? String
+        let retVal = String(data: self, encoding: .utf8)
         return retVal ?? ""
     }
 }


### PR DESCRIPTION
Hi, I've noticed a warning in your library:
```
.../Data+Representation.swift:14:84: Conditional downcast from 'NSString?' to 'String' is a bridging conversion; did you mean to use 'as'?
```
I've suggested a fix, please let me know if you see any issue with it:
