### PR TITLE
CPD-6813: Nested error support.

### DIFF
--- a/Example/JustLog.xcodeproj/project.pbxproj
+++ b/Example/JustLog.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
+		CB9EA83A1F4C68AB002D3EF5 /* NSError_UnderlyingError_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9EA8391F4C68AB002D3EF5 /* NSError_UnderlyingError_tests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,6 +53,7 @@
 		9BC0DBDFF6F20D0F760626A4 /* Pods-JustLog_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JustLog_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-JustLog_Example/Pods-JustLog_Example.release.xcconfig"; sourceTree = "<group>"; };
 		B779DCB16EBC83342A6D171D /* Pods_JustLog_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_JustLog_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD372BE74878367C4FFD8637 /* Pods-JustLog_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JustLog_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-JustLog_Tests/Pods-JustLog_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		CB9EA8391F4C68AB002D3EF5 /* NSError_UnderlyingError_tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSError_UnderlyingError_tests.swift; sourceTree = "<group>"; };
 		CDD0E7F9B7B30113E921A4BB /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		F17BCAE05ED5D114342EB2A1 /* Pods-JustLog_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JustLog_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-JustLog_Example/Pods-JustLog_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		F3D8E67BA655C94F1421168D /* Pods-JustLog_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JustLog_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-JustLog_Tests/Pods-JustLog_Tests.release.xcconfig"; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 				4F5519E81E0313F4009A8F68 /* Data_RepresentationTests.swift */,
 				4F5519DF1E02F0D7009A8F68 /* NSError_ReadabilityTests.swift */,
 				4FD9AF521E1325E600EAF51B /* String_ConversionTests.swift */,
+				CB9EA8391F4C68AB002D3EF5 /* NSError_UnderlyingError_tests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 			);
 			path = Tests;
@@ -387,6 +390,7 @@
 				4F5519E21E02F0D9009A8F68 /* Dictionary_FlatteningTests.swift in Sources */,
 				4FD9AF531E1325E600EAF51B /* String_ConversionTests.swift in Sources */,
 				4FD9AF511E12EE5F00EAF51B /* Dictionary_JSONTests.swift in Sources */,
+				CB9EA83A1F4C68AB002D3EF5 /* NSError_UnderlyingError_tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/JustLog.xcodeproj/project.pbxproj
+++ b/Example/JustLog.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
+		CB39F5BC1F4F2420009E5F68 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB39F5BB1F4F2420009E5F68 /* LoggerTests.swift */; };
 		CB9EA83A1F4C68AB002D3EF5 /* NSError_UnderlyingError_tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9EA8391F4C68AB002D3EF5 /* NSError_UnderlyingError_tests.swift */; };
 /* End PBXBuildFile section */
 
@@ -53,6 +54,7 @@
 		9BC0DBDFF6F20D0F760626A4 /* Pods-JustLog_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JustLog_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-JustLog_Example/Pods-JustLog_Example.release.xcconfig"; sourceTree = "<group>"; };
 		B779DCB16EBC83342A6D171D /* Pods_JustLog_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_JustLog_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD372BE74878367C4FFD8637 /* Pods-JustLog_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JustLog_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-JustLog_Tests/Pods-JustLog_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		CB39F5BB1F4F2420009E5F68 /* LoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggerTests.swift; sourceTree = "<group>"; };
 		CB9EA8391F4C68AB002D3EF5 /* NSError_UnderlyingError_tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSError_UnderlyingError_tests.swift; sourceTree = "<group>"; };
 		CDD0E7F9B7B30113E921A4BB /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		F17BCAE05ED5D114342EB2A1 /* Pods-JustLog_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JustLog_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-JustLog_Example/Pods-JustLog_Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 				4FD9AF521E1325E600EAF51B /* String_ConversionTests.swift */,
 				CB9EA8391F4C68AB002D3EF5 /* NSError_UnderlyingError_tests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
+				CB39F5BB1F4F2420009E5F68 /* LoggerTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -390,6 +393,7 @@
 				4F5519E21E02F0D9009A8F68 /* Dictionary_FlatteningTests.swift in Sources */,
 				4FD9AF531E1325E600EAF51B /* String_ConversionTests.swift in Sources */,
 				4FD9AF511E12EE5F00EAF51B /* Dictionary_JSONTests.swift in Sources */,
+				CB39F5BC1F4F2420009E5F68 /* LoggerTests.swift in Sources */,
 				CB9EA83A1F4C68AB002D3EF5 /* NSError_UnderlyingError_tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Tests/Dictionary_FlatteningTests.swift
+++ b/Example/Tests/Dictionary_FlatteningTests.swift
@@ -86,7 +86,6 @@ class Dictionary_Flattening: XCTestCase {
         let target = ["k1": ["v1", 2], "k2" : ["v2", 3]]
         
         XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
-        
     }
     
     func test_flattened() {
@@ -133,6 +132,8 @@ class Dictionary_Flattening: XCTestCase {
         
         XCTAssertEqual(flattened.keys.count, 3)
         XCTAssertEqual(flattened["k1"] as! String, "v1")
+        XCTAssertNil(flattened["k2"])
+        XCTAssertNil(flattened["k4"])
         XCTAssertEqual(flattened["k3"] as! String, "v3")
         XCTAssertEqual(flattened["k5"] as! String, "v5")
     }

--- a/Example/Tests/Dictionary_FlatteningTests.swift
+++ b/Example/Tests/Dictionary_FlatteningTests.swift
@@ -67,6 +67,16 @@ class Dictionary_Flattening: XCTestCase {
         XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
     }
     
+    func test_merge_byEncapsulatingFlatten_DoubleWithSameElements() {
+        let d1 = ["k1": 1.0, "k2": 2.0 ]
+        let d2 = ["k1": 3.0, "k2": 2.0, "k3" : 1.44]
+        
+        let merged = d1.merged(with: d2, policy: .encapsulateFlatten)
+        let target = ["k1": [1.0, 3.0], "k2" : [2.0, 2.0], "k3" : 1.44] as [String : Any]
+        
+        XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
+    }
+    
     func test_merge_byEncapsulatingFlatten_differentTypes() {
 
         let d1 = ["k1": "v1", "k2": "v2"]

--- a/Example/Tests/Dictionary_FlatteningTests.swift
+++ b/Example/Tests/Dictionary_FlatteningTests.swift
@@ -57,6 +57,16 @@ class Dictionary_Flattening: XCTestCase {
         XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
     }
     
+    func test_merge_byEncapsulatingFlatten_DoubleWithDifferentCountOfElements() {
+        let d1 = ["k1": 1.0, "k2": 2.0 ]
+        let d2 = ["k1": 3.0, "k2": 4.0, "k3" : 1.44]
+        
+        let merged = d1.merged(with: d2, policy: .encapsulateFlatten)
+        let target = ["k1": [1.0, 3.0], "k2" : [2.0, 4.0], "k3" : 1.44] as [String : Any]
+        
+        XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
+    }
+    
     func test_merge_byEncapsulatingFlatten_differentTypes() {
 
         let d1 = ["k1": "v1", "k2": "v2"]
@@ -117,4 +127,45 @@ class Dictionary_Flattening: XCTestCase {
         XCTAssertEqual(flattened["k5"] as! String, "v5")
     }
     
+    func test_flattenedArray_withSimpleFlattenedArray() {
+        let input: [Any] = [1,2,3,4,5,6,7]
+        let target: [Any] = [1,2,3,4,5,6,7]
+        
+        XCTAssertEqual(NSArray(array:input.flattened()), NSArray(array:target))
+    }
+
+    func test_flattenedArray_withSimpleNestedArrays() {
+        let input: [Any] = [[1,2,3],4,[5,6,7]]
+        let target: [Any] = [1,2,3,4,5,6,7]
+        
+        XCTAssertEqual(NSArray(array:input.flattened()), NSArray(array:target))
+    }
+    
+    func test_flattenedArray_withSimpleDeepNestedArrays() {
+        let input: [Any] = [[1,[2,3]],4,[5,[6,7]]]
+        let target: [Any] = [1,2,3,4,5,6,7]
+        
+        XCTAssertEqual(NSArray(array:input.flattened()), NSArray(array:target))
+    }
+
+    func test_flattenedArray_withMixedFlattenedArray() {
+        let input: [Any] = [1,2,"3",4,5,true,7.0]
+        let target: [Any] = [1,2,"3",4,5,true,7.0]
+        
+        XCTAssertEqual(NSArray(array:input.flattened()), NSArray(array:target))
+    }
+    
+    func test_flattenedArray_withMixedNestedArrays() {
+        let input: [Any] = [[1,"2",3],4,[true,6.0,7]]
+        let target: [Any] = [1,"2",3,4,true,6.0,7]
+        
+        XCTAssertEqual(NSArray(array:input.flattened()), NSArray(array:target))
+    }
+    
+    func test_flattenedArray_withMixedDeepNestedArrays() {
+        let input: [Any] = [[1,["2",3]],4,[5.9,[6,false]]]
+        let target: [Any] = [1,"2",3,4,5.9,6,false]
+        
+        XCTAssertEqual(NSArray(array:input.flattened()), NSArray(array:target))
+    }
 }

--- a/Example/Tests/Dictionary_FlatteningTests.swift
+++ b/Example/Tests/Dictionary_FlatteningTests.swift
@@ -27,67 +27,6 @@ class Dictionary_Flattening: XCTestCase {
         XCTAssertEqual(NSDictionary(dictionary:merged), NSDictionary(dictionary:target))
     }
     
-    func test_merge_byEncapsulatingFlatten() {
-        let d1 = ["k1": "v1", "k2": "v2"]
-        let d2 = ["k1": "v1b", "k2": "v2b"]
-        
-        let merged = d1.merged(with: d2, policy: .encapsulateFlatten)
-        let target = ["k1": ["v1", "v1b"], "k2" : ["v2", "v2b"]]
-        
-        XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
-    }
-    
-    func test_merge_byEncapsulatingFlatten_Int() {
-        let d1 = ["k1": 1, "k2": 2]
-        let d2 = ["k1": 3, "k2": 4]
-        
-        let merged = d1.merged(with: d2, policy: .encapsulateFlatten)
-        let target = ["k1": [1, 3], "k2" : [2, 4]]
-        
-        XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
-    }
-    
-    func test_merge_byEncapsulatingFlatten_Double() {
-        let d1 = ["k1": 1.0, "k2": 2.0]
-        let d2 = ["k1": 3.0, "k2": 4.0]
-        
-        let merged = d1.merged(with: d2, policy: .encapsulateFlatten)
-        let target = ["k1": [1.0, 3.0], "k2" : [2.0, 4.0]]
-        
-        XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
-    }
-    
-    func test_merge_byEncapsulatingFlatten_DoubleWithDifferentCountOfElements() {
-        let d1 = ["k1": 1.0, "k2": 2.0 ]
-        let d2 = ["k1": 3.0, "k2": 4.0, "k3" : 1.44]
-        
-        let merged = d1.merged(with: d2, policy: .encapsulateFlatten)
-        let target = ["k1": [1.0, 3.0], "k2" : [2.0, 4.0], "k3" : 1.44] as [String : Any]
-        
-        XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
-    }
-    
-    func test_merge_byEncapsulatingFlatten_DoubleWithSameElements() {
-        let d1 = ["k1": 1.0, "k2": 2.0 ]
-        let d2 = ["k1": 3.0, "k2": 2.0, "k3" : 1.44]
-        
-        let merged = d1.merged(with: d2, policy: .encapsulateFlatten)
-        let target = ["k1": [1.0, 3.0], "k2" : [2.0, 2.0], "k3" : 1.44] as [String : Any]
-        
-        XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
-    }
-    
-    func test_merge_byEncapsulatingFlatten_differentTypes() {
-
-        let d1 = ["k1": "v1", "k2": "v2"]
-        let d2 = ["k1": 2, "k2": 3]
-        
-        let merged = d1.merged(with: d2, policy: .encapsulateFlatten)
-        let target = ["k1": ["v1", 2], "k2" : ["v2", 3]]
-        
-        XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
-    }
-    
     func test_flattened() {
         
         let domain = "com.justeat.dictionary"

--- a/Example/Tests/Dictionary_FlatteningTests.swift
+++ b/Example/Tests/Dictionary_FlatteningTests.swift
@@ -76,46 +76,4 @@ class Dictionary_Flattening: XCTestCase {
         XCTAssertEqual(flattened["k3"] as! String, "v3")
         XCTAssertEqual(flattened["k5"] as! String, "v5")
     }
-    
-    func test_flattenedArray_withSimpleFlattenedArray() {
-        let input: [Any] = [1,2,3,4,5,6,7]
-        let target: [Any] = [1,2,3,4,5,6,7]
-        
-        XCTAssertEqual(NSArray(array:input.flattened()), NSArray(array:target))
-    }
-
-    func test_flattenedArray_withSimpleNestedArrays() {
-        let input: [Any] = [[1,2,3],4,[5,6,7]]
-        let target: [Any] = [1,2,3,4,5,6,7]
-        
-        XCTAssertEqual(NSArray(array:input.flattened()), NSArray(array:target))
-    }
-    
-    func test_flattenedArray_withSimpleDeepNestedArrays() {
-        let input: [Any] = [[1,[2,3]],4,[5,[6,7]]]
-        let target: [Any] = [1,2,3,4,5,6,7]
-        
-        XCTAssertEqual(NSArray(array:input.flattened()), NSArray(array:target))
-    }
-
-    func test_flattenedArray_withMixedFlattenedArray() {
-        let input: [Any] = [1,2,"3",4,5,true,7.0]
-        let target: [Any] = [1,2,"3",4,5,true,7.0]
-        
-        XCTAssertEqual(NSArray(array:input.flattened()), NSArray(array:target))
-    }
-    
-    func test_flattenedArray_withMixedNestedArrays() {
-        let input: [Any] = [[1,"2",3],4,[true,6.0,7]]
-        let target: [Any] = [1,"2",3,4,true,6.0,7]
-        
-        XCTAssertEqual(NSArray(array:input.flattened()), NSArray(array:target))
-    }
-    
-    func test_flattenedArray_withMixedDeepNestedArrays() {
-        let input: [Any] = [[1,["2",3]],4,[5.9,[6,false]]]
-        let target: [Any] = [1,"2",3,4,5.9,6,false]
-        
-        XCTAssertEqual(NSArray(array:input.flattened()), NSArray(array:target))
-    }
 }

--- a/Example/Tests/Dictionary_FlatteningTests.swift
+++ b/Example/Tests/Dictionary_FlatteningTests.swift
@@ -12,7 +12,7 @@ class Dictionary_Flattening: XCTestCase {
         let merged = d1.merged(with: d2)
         let target = ["k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4"]
         
-        XCTAssertEqual(merged, target)
+        XCTAssertEqual(NSDictionary(dictionary:merged), NSDictionary(dictionary: target))
     }
     
     func test_merge_withConflictingDictionies() {
@@ -23,7 +23,16 @@ class Dictionary_Flattening: XCTestCase {
         let merged = d1.merged(with: d2)
         let target = ["k1": "v1b", "k2": "v2", "k3": "v3"]
         
-        XCTAssertEqual(merged, target)
+        XCTAssertEqual(NSDictionary(dictionary:merged), NSDictionary(dictionary:target))
+    }
+    
+    func test_merge_byEncapsulatingFlatten() {
+        let d1 = ["k1": "v1", "k2": "v2"]
+        let d2 = ["k1": "v1b", "k2": "v2b"]
+        let merged = mergeDictionary(d1, with: d2)
+        let target = ["k1": ["v1", "v1b"], "k2" : ["v2", "v2b"]]
+        
+        XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
     }
     
     func test_flattened() {

--- a/Example/Tests/Dictionary_FlatteningTests.swift
+++ b/Example/Tests/Dictionary_FlatteningTests.swift
@@ -20,6 +20,7 @@ class Dictionary_Flattening: XCTestCase {
         let d1 = ["k1": "v1", "k2": "v2"]
         let d2 = ["k1": "v1b", "k3": "v3"]
         
+        
         let merged = d1.merged(with: d2)
         let target = ["k1": "v1b", "k2": "v2", "k3": "v3"]
         
@@ -29,10 +30,43 @@ class Dictionary_Flattening: XCTestCase {
     func test_merge_byEncapsulatingFlatten() {
         let d1 = ["k1": "v1", "k2": "v2"]
         let d2 = ["k1": "v1b", "k2": "v2b"]
-        let merged = mergeDictionary(d1, with: d2)
+        
+        let merged = d1.merged(with: d2, policy: .encapsulateFlatten)
         let target = ["k1": ["v1", "v1b"], "k2" : ["v2", "v2b"]]
         
         XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
+    }
+    
+    func test_merge_byEncapsulatingFlatten_Int() {
+        let d1 = ["k1": 1, "k2": 2]
+        let d2 = ["k1": 3, "k2": 4]
+        
+        let merged = d1.merged(with: d2, policy: .encapsulateFlatten)
+        let target = ["k1": [1, 3], "k2" : [2, 4]]
+        
+        XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
+    }
+    
+    func test_merge_byEncapsulatingFlatten_Double() {
+        let d1 = ["k1": 1.0, "k2": 2.0]
+        let d2 = ["k1": 3.0, "k2": 4.0]
+        
+        let merged = d1.merged(with: d2, policy: .encapsulateFlatten)
+        let target = ["k1": [1.0, 3.0], "k2" : [2.0, 4.0]]
+        
+        XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
+    }
+    
+    func test_merge_byEncapsulatingFlatten_differentTypes() {
+
+        let d1 = ["k1": "v1", "k2": "v2"]
+        let d2 = ["k1": 2, "k2": 3]
+        
+        let merged = d1.merged(with: d2, policy: .encapsulateFlatten)
+        let target = ["k1": ["v1", 2], "k2" : ["v2", 3]]
+        
+        XCTAssertEqual(NSDictionary(dictionary: merged), NSDictionary(dictionary: target))
+        
     }
     
     func test_flattened() {

--- a/Example/Tests/LoggerTests.swift
+++ b/Example/Tests/LoggerTests.swift
@@ -39,7 +39,7 @@ class LoggerTests: XCTestCase {
             ] as [String : Any]
         let error = NSError(domain: "com.just-eat.error", code: 1234, userInfo: userInfo)
         let dict = Logger.shared.errorDictionary(for: error)
-        let dictUserInfo = dict["userInfo"] as! [String : Any]
+        let dictUserInfo = dict["user_info"] as! [String : Any]
         
         XCTAssertEqual(userInfo[NSLocalizedFailureReasonErrorKey] as! String, dictUserInfo[NSLocalizedFailureReasonErrorKey] as! String)
         XCTAssertEqual(userInfo[NSLocalizedDescriptionKey] as! String, dictUserInfo[NSLocalizedDescriptionKey] as! String)

--- a/Example/Tests/LoggerTests.swift
+++ b/Example/Tests/LoggerTests.swift
@@ -1,0 +1,49 @@
+//
+//  LoggerTests.swift
+//  JustLog
+//
+//  Created by Alkiviadis Papadakis on 24/08/2017.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import JustLog
+
+class LoggerTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        _ = Logger.shared
+    }
+    
+    func test_errorDictionary_ReturnsDictionaryForError() {
+        let userInfo = [
+            NSLocalizedFailureReasonErrorKey: "error value",
+            NSLocalizedDescriptionKey: "description",
+            NSLocalizedRecoverySuggestionErrorKey: "recovery suggestion"
+            ] as [String : Any]
+        let error = NSError(domain: "com.just-eat.error", code: 1234, userInfo: userInfo)
+        let dict = Logger.shared.errorDictionary(for: error)
+        
+        XCTAssertNotNil(dict["userInfo"])
+        XCTAssertNotNil(dict["error_code"])
+        XCTAssertNotNil(dict["error_domain"])
+        
+    }
+    
+    func test_errorDictionary_ReturnedDictionaryContainsUserInfo() {
+        let userInfo = [
+            NSLocalizedFailureReasonErrorKey: "error value",
+            NSLocalizedDescriptionKey: "description",
+            NSLocalizedRecoverySuggestionErrorKey: "recovery suggestion"
+            ] as [String : Any]
+        let error = NSError(domain: "com.just-eat.error", code: 1234, userInfo: userInfo)
+        let dict = Logger.shared.errorDictionary(for: error)
+        let dictUserInfo = dict["userInfo"] as! [String : Any]
+        
+        XCTAssertEqual(userInfo[NSLocalizedFailureReasonErrorKey] as! String, dictUserInfo[NSLocalizedFailureReasonErrorKey] as! String)
+        XCTAssertEqual(userInfo[NSLocalizedDescriptionKey] as! String, dictUserInfo[NSLocalizedDescriptionKey] as! String)
+        XCTAssertEqual(userInfo[NSLocalizedRecoverySuggestionErrorKey] as! String, dictUserInfo[NSLocalizedRecoverySuggestionErrorKey] as! String)
+        XCTAssertNotNil(dict["error_domain"])
+    }
+}

--- a/Example/Tests/LoggerTests.swift
+++ b/Example/Tests/LoggerTests.swift
@@ -46,4 +46,9 @@ class LoggerTests: XCTestCase {
         XCTAssertEqual(userInfo[NSLocalizedRecoverySuggestionErrorKey] as! String, dictUserInfo[NSLocalizedRecoverySuggestionErrorKey] as! String)
         XCTAssertNotNil(dict["error_domain"])
     }
+    
+//    func test_metadataDictionary_ReturnsDictionaryForMetadata() {
+//        let metadataDictionary = Logger.shared.metadataDictionary("thisFile.swift", "a function name", 33)
+//        XCTAssert
+//    }
 }

--- a/Example/Tests/LoggerTests.swift
+++ b/Example/Tests/LoggerTests.swift
@@ -25,7 +25,7 @@ class LoggerTests: XCTestCase {
         let error = NSError(domain: "com.just-eat.error", code: 1234, userInfo: userInfo)
         let dict = Logger.shared.errorDictionary(for: error)
         
-        XCTAssertNotNil(dict["userInfo"])
+        XCTAssertNotNil(dict["user_info"])
         XCTAssertNotNil(dict["error_code"])
         XCTAssertNotNil(dict["error_domain"])
         

--- a/Example/Tests/NSError_ReadabilityTests.swift
+++ b/Example/Tests/NSError_ReadabilityTests.swift
@@ -67,5 +67,4 @@ class NSError_Flattening: XCTestCase {
         // Then
         XCTAssertEqual(expectedReadableError, readableError)
     }
-    
 }

--- a/Example/Tests/NSError_ReadabilityTests.swift
+++ b/Example/Tests/NSError_ReadabilityTests.swift
@@ -67,47 +67,4 @@ class NSError_Flattening: XCTestCase {
         // Then
         XCTAssertEqual(expectedReadableError, readableError)
     }
-    
-    func test_GivenAnErrorWithUnderlyingError_WhenCallingLogMessage_ThenJsonStructureOfErrorShouldBeReturned() {
-        
-        let innerInnerUserInfoError = [
-            NSLocalizedFailureReasonErrorKey: "inner inner error value",
-            NSLocalizedDescriptionKey: "inner inner description",
-            NSLocalizedRecoverySuggestionErrorKey: "inner inner recovery suggestion"
-            ] as [String : Any]
-        
-        let underlyingReadableUserInfoError = [
-            NSUnderlyingErrorKey: NSError(domain: "com.just-eat.test.inner.inner", code: 9999, userInfo: innerInnerUserInfoError),
-            NSLocalizedFailureReasonErrorKey: "inner error value",
-            NSLocalizedDescriptionKey: "inner description",
-            NSLocalizedRecoverySuggestionErrorKey: "inner recovery suggestion"
-            ] as [String : Any]
-        
-        let readableUserInfos = [
-            NSUnderlyingErrorKey: NSError(domain: "com.just-eat.test.inner", code: 5678, userInfo: underlyingReadableUserInfoError),
-            NSLocalizedFailureReasonErrorKey: "error value",
-            NSLocalizedDescriptionKey: "description",
-            NSLocalizedRecoverySuggestionErrorKey: "recovery suggestion"
-            ] as [String : Any]
-        
-        let unreadableError = NSError(domain: "com.just-eat.test", code:1234, userInfo:readableUserInfos)
-        
-        let errors = unreadableError.underlyingErrors()
-        let errorsIncludingSelf = unreadableError.errorChain()
-        XCTAssertEqual(errors.count, 2)
-        XCTAssertEqual(errorsIncludingSelf.count, 3)
-        
-        let message = Logger.shared.logMessage("Message to attach", error: unreadableError, userInfo: ["SomeCustomKey" : "SomeCustomValue"], #file, #function, #line)
-        
-        if let dict = message.toDictionary()
-        {
-            print(dict)
-        }
-        let flattenedUserInfo = (unreadableError.userInfo as! [String: Any]).flattened(policy: .encapsulateFlatten)
-        
-        
-        print(flattenedUserInfo)
-        print(message)
-        
-    }
 }

--- a/Example/Tests/NSError_ReadabilityTests.swift
+++ b/Example/Tests/NSError_ReadabilityTests.swift
@@ -99,11 +99,14 @@ class NSError_Flattening: XCTestCase {
         
         let message = Logger.shared.logMessage("Message to attach", error: unreadableError, userInfo: ["SomeCustomKey" : "SomeCustomValue"], #file, #function, #line)
         
-//        let target = "{\"metadata\":{\"file\":\"NSError_ReadabilityTests.swift\",\"je_feature_version\":\"1.2.0 (1)\",\"je_ios_version\":\"10.3.1\",\"function\":\"test_GivenAnErrorWithUnderlyingError_WhenCallingLogMessage_ThenJsonStructureOfErrorShouldBeReturned()\",\"je_ios_device\":\"x86_64\",\"line\":\"100\"},\"userInfo\":{\"error_code\":[1234,5678,9999],\"je_environment\":\"production\",\"x-je-conversation\":\"FB7DF45D-F491-49DE-B9BF-EABAAC2F95E8\",\"error_domain\":[\"com.just-eat.test\",\"com.just-eat.test.inner\",\"com.just-eat.test.inner.inner\"],\"SomeCustomKey\":\"SomeCustomValue\",\"NSLocalizedDescription\":[\"inner inner description\",\"inner inner description\",\"inner inner description\"],\"NSLocalizedRecoverySuggestion\":[\"inner inner recovery suggestion\",\"inner inner recovery suggestion\",\"inner inner recovery suggestion\"],\"je_feature\":\"ios cia\",\"je_tenant\":\"UK\",\"NSLocalizedFailureReason\":[\"error value\",\"inner error value\",\"inner inner error value\"]},\"message\":\"Message to attach\"}"
-//        
-//        XCTAssertTrue(message == target)
+        if let dict = message.toDictionary()
+        {
+            print(dict)
+        }
+        let flattenedUserInfo = (unreadableError.userInfo as! [String: Any]).flattened(policy: .encapsulateFlatten)
         
-//        let data = JSONSerialization.jsonObject(with: target.data(using: .utf8), options: .allowFragments)
+        
+        print(flattenedUserInfo)
         print(message)
         
     }

--- a/Example/Tests/NSError_ReadabilityTests.swift
+++ b/Example/Tests/NSError_ReadabilityTests.swift
@@ -67,4 +67,44 @@ class NSError_Flattening: XCTestCase {
         // Then
         XCTAssertEqual(expectedReadableError, readableError)
     }
+    
+    func test_GivenAnErrorWithUnderlyingError_WhenCallingLogMessage_ThenJsonStructureOfErrorShouldBeReturned() {
+        
+        let innerInnerUserInfoError = [
+            NSLocalizedFailureReasonErrorKey: "inner inner error value",
+            NSLocalizedDescriptionKey: "inner inner description",
+            NSLocalizedRecoverySuggestionErrorKey: "inner inner recovery suggestion"
+            ] as [String : Any]
+        
+        let underlyingReadableUserInfoError = [
+            NSUnderlyingErrorKey: NSError(domain: "com.just-eat.test.inner.inner", code: 9999, userInfo: innerInnerUserInfoError),
+            NSLocalizedFailureReasonErrorKey: "inner error value",
+            NSLocalizedDescriptionKey: "inner description",
+            NSLocalizedRecoverySuggestionErrorKey: "inner recovery suggestion"
+            ] as [String : Any]
+        
+        let readableUserInfos = [
+            NSUnderlyingErrorKey: NSError(domain: "com.just-eat.test.inner", code: 5678, userInfo: underlyingReadableUserInfoError),
+            NSLocalizedFailureReasonErrorKey: "error value",
+            NSLocalizedDescriptionKey: "description",
+            NSLocalizedRecoverySuggestionErrorKey: "recovery suggestion"
+            ] as [String : Any]
+        
+        let unreadableError = NSError(domain: "com.just-eat.test", code:1234, userInfo:readableUserInfos)
+        
+        let errors = unreadableError.underlyingErrors()
+        let errorsIncludingSelf = unreadableError.errorChain()
+        XCTAssertEqual(errors.count, 2)
+        XCTAssertEqual(errorsIncludingSelf.count, 3)
+        
+        let message = Logger.shared.logMessage("Message to attach", error: unreadableError, userInfo: ["SomeCustomKey" : "SomeCustomValue"], #file, #function, #line)
+        
+//        let target = "{\"metadata\":{\"file\":\"NSError_ReadabilityTests.swift\",\"je_feature_version\":\"1.2.0 (1)\",\"je_ios_version\":\"10.3.1\",\"function\":\"test_GivenAnErrorWithUnderlyingError_WhenCallingLogMessage_ThenJsonStructureOfErrorShouldBeReturned()\",\"je_ios_device\":\"x86_64\",\"line\":\"100\"},\"userInfo\":{\"error_code\":[1234,5678,9999],\"je_environment\":\"production\",\"x-je-conversation\":\"FB7DF45D-F491-49DE-B9BF-EABAAC2F95E8\",\"error_domain\":[\"com.just-eat.test\",\"com.just-eat.test.inner\",\"com.just-eat.test.inner.inner\"],\"SomeCustomKey\":\"SomeCustomValue\",\"NSLocalizedDescription\":[\"inner inner description\",\"inner inner description\",\"inner inner description\"],\"NSLocalizedRecoverySuggestion\":[\"inner inner recovery suggestion\",\"inner inner recovery suggestion\",\"inner inner recovery suggestion\"],\"je_feature\":\"ios cia\",\"je_tenant\":\"UK\",\"NSLocalizedFailureReason\":[\"error value\",\"inner error value\",\"inner inner error value\"]},\"message\":\"Message to attach\"}"
+//        
+//        XCTAssertTrue(message == target)
+        
+//        let data = JSONSerialization.jsonObject(with: target.data(using: .utf8), options: .allowFragments)
+        print(message)
+        
+    }
 }

--- a/Example/Tests/NSError_UnderlyingError_tests.swift
+++ b/Example/Tests/NSError_UnderlyingError_tests.swift
@@ -1,0 +1,110 @@
+//
+//  NSError_UnderlyingError_tests.swift
+//  JustLog
+//
+//  Created by Alkiviadis Papadakis on 22/08/2017.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import JustLog
+
+class NSError_UnderlyingError_tests: XCTestCase {
+
+    func test_ErrorChain_ReturnsArrayOfAssociatedErrorsIncludingSelf() {
+        
+        let innerInnerUserInfoError = [
+            NSLocalizedFailureReasonErrorKey: "inner inner error value",
+            NSLocalizedDescriptionKey: "inner inner description",
+            NSLocalizedRecoverySuggestionErrorKey: "inner inner recovery suggestion"
+            ] as [String : Any]
+        
+        let innerInnerError: NSError = NSError(domain: "com.just-eat.test.inner.inner", code: 9999, userInfo: innerInnerUserInfoError)
+        let underlyingReadableUserInfoError = [
+            NSUnderlyingErrorKey: innerInnerError,
+            NSLocalizedFailureReasonErrorKey: "inner error value",
+            NSLocalizedDescriptionKey: "inner description",
+            NSLocalizedRecoverySuggestionErrorKey: "inner recovery suggestion"
+            ] as [String : Any]
+        
+        let innerError: NSError = NSError(domain: "com.just-eat.test.inner", code: 5678, userInfo: underlyingReadableUserInfoError)
+        let readableUserInfos = [
+            NSUnderlyingErrorKey: innerError,
+            NSLocalizedFailureReasonErrorKey: "error value",
+            NSLocalizedDescriptionKey: "description",
+            NSLocalizedRecoverySuggestionErrorKey: "recovery suggestion"
+            ] as [String : Any]
+        
+        let error = NSError(domain: "com.just-eat.test", code:1234, userInfo:readableUserInfos)
+        let associatedErrors = error.errorChain()
+        
+        XCTAssertTrue(associatedErrors.contains(innerInnerError))
+        XCTAssertTrue(associatedErrors.contains(innerError))
+        XCTAssertTrue(associatedErrors.contains(error))
+    }
+    
+    func test_underlyingErrors_ReturnsArrayOfAssociatedErrorsExcludingSelf() {
+        
+        let innerInnerUserInfoError = [
+            NSLocalizedFailureReasonErrorKey: "inner inner error value",
+            NSLocalizedDescriptionKey: "inner inner description",
+            NSLocalizedRecoverySuggestionErrorKey: "inner inner recovery suggestion"
+            ] as [String : Any]
+        
+        let innerInnerError: NSError = NSError(domain: "com.just-eat.test.inner.inner", code: 9999, userInfo: innerInnerUserInfoError)
+        let underlyingReadableUserInfoError = [
+            NSUnderlyingErrorKey: innerInnerError,
+            NSLocalizedFailureReasonErrorKey: "inner error value",
+            NSLocalizedDescriptionKey: "inner description",
+            NSLocalizedRecoverySuggestionErrorKey: "inner recovery suggestion"
+            ] as [String : Any]
+        
+        let innerError: NSError = NSError(domain: "com.just-eat.test.inner", code: 5678, userInfo: underlyingReadableUserInfoError)
+        let readableUserInfos = [
+            NSUnderlyingErrorKey: innerError,
+            NSLocalizedFailureReasonErrorKey: "error value",
+            NSLocalizedDescriptionKey: "description",
+            NSLocalizedRecoverySuggestionErrorKey: "recovery suggestion"
+            ] as [String : Any]
+        
+        let error = NSError(domain: "com.just-eat.test", code:1234, userInfo:readableUserInfos)
+        let associatedErrors = error.underlyingErrors()
+        
+        XCTAssertTrue(associatedErrors.contains(innerInnerError))
+        XCTAssertTrue(associatedErrors.contains(innerError))
+        XCTAssertFalse(associatedErrors.contains(error))
+    }
+    
+    func test_disassociatedErrorChain_ReturnsArrayOfNonAssociatedErrorsIncludingSelfWithNoUnderlyingErrorKey() {
+        
+        let innerInnerUserInfoError = [
+            NSLocalizedFailureReasonErrorKey: "inner inner error value",
+            NSLocalizedDescriptionKey: "inner inner description",
+            NSLocalizedRecoverySuggestionErrorKey: "inner inner recovery suggestion"
+            ] as [String : Any]
+        
+        let innerInnerError: NSError = NSError(domain: "com.just-eat.test.inner.inner", code: 9999, userInfo: innerInnerUserInfoError)
+        let underlyingReadableUserInfoError = [
+            NSUnderlyingErrorKey: innerInnerError,
+            NSLocalizedFailureReasonErrorKey: "inner error value",
+            NSLocalizedDescriptionKey: "inner description",
+            NSLocalizedRecoverySuggestionErrorKey: "inner recovery suggestion"
+            ] as [String : Any]
+        
+        let innerError: NSError = NSError(domain: "com.just-eat.test.inner", code: 5678, userInfo: underlyingReadableUserInfoError)
+        let readableUserInfos = [
+            NSUnderlyingErrorKey: innerError,
+            NSLocalizedFailureReasonErrorKey: "error value",
+            NSLocalizedDescriptionKey: "description",
+            NSLocalizedRecoverySuggestionErrorKey: "recovery suggestion"
+            ] as [String : Any]
+        
+        let error = NSError(domain: "com.just-eat.test", code:1234, userInfo:readableUserInfos)
+        let associatedErrors = error.disassociatedErrorChain()
+        
+        XCTAssertTrue(associatedErrors.count == 3)
+        for error in associatedErrors {
+            XCTAssertFalse(error.userInfo[NSUnderlyingErrorKey] != nil)
+        }
+    }
+}

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -56,7 +56,7 @@ public final class Logger: NSObject {
     public var enableFileLogging: Bool = true
     public var enableLogstashLogging: Bool = true
     public let internalLogger = SwiftyBeaver.self
-    public var eventLogingPolicy: ErrorLoggingPolicy = .singleEvent
+    public var loggingPolicy: ErrorLoggingPolicy = .singleEvent
     private var dispatchTimer: Timer?
     
     // destinations
@@ -152,21 +152,17 @@ extension Logger: Logging {
     }
     
     internal func log(_ type: LogType, _ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: UInt) {
-        switch self.eventLogingPolicy {
-        case .singleEvent :
-            let logMessage = self.logMessage(message, error: error, userInfo: userInfo, file, function, line)
-            sendLogMessage(with: type, logMessage: logMessage, file, function, line)
-        case .multipleEvents:
+        switch loggingPolicy {
+        case .multipleEvents where type == .error:
             if let error  = error {
                 for error in error.disassociatedErrorChain() {
-                    let logMessage = self.logMessage(message, error: error, userInfo: userInfo, file, function, line)
-                    sendLogMessage(with: type, logMessage: logMessage, file, function, line)
+                    let messageToLog = logMessage(message, error: error, userInfo: userInfo, file, function, line)
+                    sendLogMessage(with: type, logMessage: messageToLog, file, function, line)
                 }
             }
-            else {
-                let logMessage = self.logMessage(message, error: error, userInfo: userInfo, file, function, line)
-                sendLogMessage(with: type, logMessage: logMessage, file, function, line)
-            }
+        default:
+            let messageToLog = logMessage(message, error: error, userInfo: userInfo, file, function, line)
+            sendLogMessage(with: type, logMessage: messageToLog, file, function, line)
         }
     }
     

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -183,7 +183,7 @@ extension Logger {
         if let error = error {
             let errorInfo = [errorDomain: error.domain,
                              errorCode: error.code] as [String : Any]
-            let errorUserInfo = error.humanReadableError().userInfo
+            let errorUserInfo = error.humanReadableError().userInfo as! [String : Any]
             options = options.merged(with: errorInfo).merged(with: errorUserInfo.flattened())
         }
         

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -171,7 +171,7 @@ extension Logger {
     internal func logMessage(_ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: UInt) -> String {
     
         let messageConst = "message"
-        let userInfoConst = "userInfo"
+        let userInfoConst = "user_info"
         let metadataConst = "metadata"
         let errorsConst = "errors"
         
@@ -223,7 +223,7 @@ extension Logger {
     }
     
     internal func errorDictionary(for error: NSError) -> [String : Any] {
-        let userInfoConst = "userInfo"
+        let userInfoConst = "user_info"
         var errorInfo = [errorDomain: error.domain,
                          errorCode: error.code] as [String : Any]
         let errorUserInfo = error.humanReadableError().userInfo as! [String : Any]

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -12,11 +12,6 @@ import SwiftyBeaver
 @objc
 public final class Logger: NSObject {
     
-    public enum ErrorLoggingPolicy {
-        case singleEvent
-        case multipleEvents
-    }
-    
     internal enum LogType {
         case debug
         case warning
@@ -56,7 +51,6 @@ public final class Logger: NSObject {
     public var enableFileLogging: Bool = true
     public var enableLogstashLogging: Bool = true
     public let internalLogger = SwiftyBeaver.self
-    public var loggingPolicy: ErrorLoggingPolicy = .singleEvent
     private var dispatchTimer: Timer?
     
     // destinations
@@ -152,18 +146,8 @@ extension Logger: Logging {
     }
     
     internal func log(_ type: LogType, _ message: String, error: NSError?, userInfo: [String : Any]?, _ file: String, _ function: String, _ line: UInt) {
-        switch loggingPolicy {
-        case .multipleEvents where type == .error:
-            if let error  = error {
-                for error in error.disassociatedErrorChain() {
-                    let messageToLog = logMessage(message, error: error, userInfo: userInfo, file, function, line)
-                    sendLogMessage(with: type, logMessage: messageToLog, file, function, line)
-                }
-            }
-        default:
-            let messageToLog = logMessage(message, error: error, userInfo: userInfo, file, function, line)
-            sendLogMessage(with: type, logMessage: messageToLog, file, function, line)
-        }
+        let messageToLog = logMessage(message, error: error, userInfo: userInfo, file, function, line)
+        sendLogMessage(with: type, logMessage: messageToLog, file, function, line)
     }
     
     internal func sendLogMessage(with type: LogType, logMessage: String, _ file: String, _ function: String, _ line: UInt) {

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -190,12 +190,7 @@ extension Logger {
 
         
         if let error = error {
-            var errorInfoArray: [[String : Any]] = []
-            error.disassociatedErrorChain().forEach({ (underlyingError) in
-                let errorDict = errorDictionary(for: underlyingError)
-                errorInfoArray.append(errorDict)
-            })
-            retVal[errorsConst] = errorInfoArray
+            retVal[errorsConst] = error.disassociatedErrorChain().map { return errorDictionary(for: $0) }
         }
         
         

--- a/JustLog/Extensions/Data+Representation.swift
+++ b/JustLog/Extensions/Data+Representation.swift
@@ -11,7 +11,6 @@ import Foundation
 extension Data {
     
     func stringRepresentation() -> String {
-        let retVal = NSString(data: self, encoding: String.Encoding.utf8.rawValue) as String?
-        return retVal ?? ""
+        return String(data: self, encoding: .utf8) ?? ""
     }
 }

--- a/JustLog/Extensions/Dictionary+Flattening.swift
+++ b/JustLog/Extensions/Dictionary+Flattening.swift
@@ -8,19 +8,6 @@
 
 import Foundation
 
-public func mergeDictionary(_ dictionary: Dictionary<String, Any>, with dictionary2: Dictionary<String, Any>) -> Dictionary<String, Any> {
-    var retVal: Dictionary<String, Any> = [:]
-    dictionary2.forEach { (key, value) in
-        if let value1 = dictionary[key] {
-            let mergedValue: [Any] = [value1, value]
-            retVal.updateValue(mergedValue, forKey: key)
-        }
-        else {
-            retVal.updateValue(value, forKey: key)
-        }
-    }
-    return retVal
-}
 
 extension Dictionary {
     
@@ -66,19 +53,34 @@ extension Dictionary where Key == String {
         case encapsulateFlatten
     }
     
-    mutating func merge(with dictionary: Dictionary) {
-        dictionary.forEach { _ = updateValue($1, forKey: $0) }
-    }
-    
-    
-    func merged(with dictionary: Dictionary, policy: KeyMergePolicy = .override) -> Dictionary<String, Any> {
+    func merged(with dictionary: Dictionary<String, Any>, policy: KeyMergePolicy = .override) -> Dictionary<String, Any> {
         switch policy {
         case .override:
-            var dict = self
-            dict.merge(with: dictionary)
-            return dict
+            return mergeDictionaryByReplacingValues(self, with: dictionary)
         case .encapsulateFlatten:
-            return mergeDictionary(self, with: dictionary)
+            return mergeDictionariesByGroupingValues(self, with: dictionary)
         }
+    }
+    
+    private func mergeDictionaryByReplacingValues(_ dictionary: Dictionary<String, Any>, with dictionary2: Dictionary<String, Any>) -> Dictionary<String, Any> {
+        var retValue = dictionary
+        dictionary2.forEach { (key, value) in
+            retValue.updateValue(value, forKey: key)
+        }
+        return retValue
+    }
+    
+    private func mergeDictionariesByGroupingValues(_ dictionary: Dictionary<String, Any>, with dictionary2: Dictionary<String, Any>) -> Dictionary<String, Any> {
+        var retVal: Dictionary<String, Any> = [:]
+        dictionary2.forEach { (key, value) in
+            if let value1 = dictionary[key] {
+                let mergedValue: [Any] = [value1, value]
+                retVal.updateValue(mergedValue, forKey: key)
+            }
+            else {
+                retVal.updateValue(value, forKey: key)
+            }
+        }
+        return retVal
     }
 }

--- a/JustLog/Extensions/Dictionary+Flattening.swift
+++ b/JustLog/Extensions/Dictionary+Flattening.swift
@@ -7,19 +7,18 @@
 //
 
 import Foundation
-
+enum KeyMergePolicy {
+    case override
+    case encapsulateFlatten
+}
 extension Dictionary where Key == String {
     
     /// Defines how the dictionary will be flattened and the key-value pairs will be merged.
     ///
     /// - override: Overrides the keys and the values.
     /// - encapsulateFlatten: keeps the keys and adds the values to an array.
-    enum KeyMergePolicy {
-        case override
-        case encapsulateFlatten
-    }
     
-    func flattened() -> [String : Any] {
+    func flattened(policy: KeyMergePolicy = .override) -> [String : Any] {
         
         var retVal = [String : Any]()
         
@@ -32,8 +31,8 @@ extension Dictionary where Key == String {
                 retVal.updateValue(v, forKey: k)
             case is [String : Any]:
                 if let value: [String : Any] = v as? [String : Any] {
-                    let inner = value.flattened()
-                    retVal = retVal.merged(with: inner)
+                    let inner = value.flattened(policy: policy)
+                    retVal = retVal.merged(with: inner, policy: policy)
                 }
                 else {
                     continue
@@ -42,7 +41,7 @@ extension Dictionary where Key == String {
                 retVal.updateValue(String(describing: v), forKey: k)
             case is NSError:
                 if let inner = v as? NSError, let userInfo: [String: Any] = inner.userInfo as? [String : Any] {
-                    retVal = retVal.merged(with: userInfo.flattened())
+                    retVal = retVal.merged(with: userInfo.flattened(policy: policy), policy: policy)
                 }
                 else {
                     continue
@@ -105,5 +104,6 @@ extension Array where Element == Any {
         }
         return arraythings
     }
+    
 
 }

--- a/JustLog/Extensions/Dictionary+Flattening.swift
+++ b/JustLog/Extensions/Dictionary+Flattening.swift
@@ -59,20 +59,3 @@ extension Dictionary where Key == String {
         return retValue
     }
 }
-
-extension Array where Element == Any {
-    
-    func flattened() -> [Any] {
-        var flattenedArray: [Any] = []
-        for element in self {
-            switch element {
-            case is [Any]:
-               let elementsArray = element as! [Any]
-               flattenedArray.append(contentsOf: elementsArray.flattened())
-            default:
-               flattenedArray.append(element)
-            }
-        }
-        return flattenedArray
-    }
-}

--- a/JustLog/Extensions/Dictionary+Flattening.swift
+++ b/JustLog/Extensions/Dictionary+Flattening.swift
@@ -8,17 +8,21 @@
 
 import Foundation
 
+public func mergeDictionary(_ dictionary: Dictionary<String, Any>, with dictionary2: Dictionary<String, Any>) -> Dictionary<String, Any> {
+    var retVal: Dictionary<String, Any> = [:]
+    dictionary2.forEach { (key, value) in
+        if let value1 = dictionary[key] {
+            let mergedValue: [Any] = [value1, value]
+            retVal.updateValue(mergedValue, forKey: key)
+        }
+        else {
+            retVal.updateValue(value, forKey: key)
+        }
+    }
+    return retVal
+}
+
 extension Dictionary {
-    
-    mutating func merge(with dictionary: Dictionary) {
-        dictionary.forEach { _ = updateValue($1, forKey: $0) }
-    }
-    
-    func merged(with dictionary: Dictionary) -> Dictionary {
-        var dict = self
-        dict.merge(with: dictionary)
-        return dict
-    }
     
     func flattened() -> [String : Any] {
         
@@ -46,8 +50,35 @@ extension Dictionary {
                 continue
             }
         }
-
+        
         return retVal
     }
+}
+
+extension Dictionary where Key == String {
     
+    /// Defines how the dictionary will be flattened and the key-value pairs will be merged.
+    ///
+    /// - override: Overrides the keys and the values.
+    /// - encapsulateFlatten: keeps the keys and adds the values to an array.
+    enum KeyMergePolicy {
+        case override
+        case encapsulateFlatten
+    }
+    
+    mutating func merge(with dictionary: Dictionary) {
+        dictionary.forEach { _ = updateValue($1, forKey: $0) }
+    }
+    
+    
+    func merged(with dictionary: Dictionary, policy: KeyMergePolicy = .override) -> Dictionary<String, Any> {
+        switch policy {
+        case .override:
+            var dict = self
+            dict.merge(with: dictionary)
+            return dict
+        case .encapsulateFlatten:
+            return mergeDictionary(self, with: dictionary)
+        }
+    }
 }

--- a/JustLog/Extensions/Dictionary+Flattening.swift
+++ b/JustLog/Extensions/Dictionary+Flattening.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+
 enum KeyMergePolicy {
     case override
     case encapsulateFlatten
@@ -53,7 +54,6 @@ extension Dictionary where Key == String {
         
         return retVal
     }
-
     
     func merged(with dictionary: [String : Any], policy: KeyMergePolicy = .override) -> [String : Any] {
         switch policy {

--- a/JustLog/Extensions/Dictionary+Flattening.swift
+++ b/JustLog/Extensions/Dictionary+Flattening.swift
@@ -8,10 +8,6 @@
 
 import Foundation
 
-enum KeyMergePolicy {
-    case override
-    case encapsulateFlatten
-}
 extension Dictionary where Key == String {
     
     /// Defines how the dictionary will be flattened and the key-value pairs will be merged.
@@ -19,7 +15,7 @@ extension Dictionary where Key == String {
     /// - override: Overrides the keys and the values.
     /// - encapsulateFlatten: keeps the keys and adds the values to an array.
     
-    func flattened(policy: KeyMergePolicy = .override) -> [String : Any] {
+    func flattened() -> [String : Any] {
         
         var retVal = [String : Any]()
         
@@ -32,8 +28,8 @@ extension Dictionary where Key == String {
                 retVal.updateValue(v, forKey: k)
             case is [String : Any]:
                 if let value: [String : Any] = v as? [String : Any] {
-                    let inner = value.flattened(policy: policy)
-                    retVal = retVal.merged(with: inner, policy: policy)
+                    let inner = value.flattened()
+                    retVal = retVal.merged(with: inner)
                 }
                 else {
                     continue
@@ -42,7 +38,7 @@ extension Dictionary where Key == String {
                 retVal.updateValue(String(describing: v), forKey: k)
             case is NSError:
                 if let inner = v as? NSError, let userInfo: [String: Any] = inner.userInfo as? [String : Any] {
-                    retVal = retVal.merged(with: userInfo.flattened(policy: policy), policy: policy)
+                    retVal = retVal.merged(with: userInfo.flattened())
                 }
                 else {
                     continue
@@ -55,39 +51,14 @@ extension Dictionary where Key == String {
         return retVal
     }
     
-    func merged(with dictionary: [String : Any], policy: KeyMergePolicy = .override) -> [String : Any] {
-        switch policy {
-        case .override:
-            return mergeDictionaryByReplacingValues(self, with: dictionary)
-        case .encapsulateFlatten:
-            return mergeDictionariesByGroupingValues(self, with: dictionary)
-        }
-    }
-    
-    private func mergeDictionaryByReplacingValues(_ dictionary: [String : Any], with dictionary2: [String : Any]) -> [String : Any] {
-        var retValue = dictionary
-        dictionary2.forEach { (key, value) in
+    func merged(with dictionary: [String : Any]) -> [String : Any] {
+        var retValue = self as [String :Any]
+        dictionary.forEach { (key, value) in
             retValue.updateValue(value, forKey: key)
         }
         return retValue
     }
-    
-    private func mergeDictionariesByGroupingValues(_ dictionary: [String : Any], with dictionary2: [String : Any]) -> [String : Any] {
-        var retVal = dictionary
-        dictionary2.forEach { (key, value) in
-            if let value1 = dictionary[key] {
-                let mergedValue: [Any] = [value1, value]
-                let flattenedArray = mergedValue.flattened()
-                retVal.updateValue(flattenedArray, forKey: key)
-            }
-            else {
-                retVal.updateValue(value, forKey: key)
-            }
-        }
-        return retVal
-    }
-    
-   }
+}
 
 extension Array where Element == Any {
     
@@ -104,6 +75,4 @@ extension Array where Element == Any {
         }
         return flattenedArray
     }
-    
-
 }

--- a/JustLog/Extensions/Dictionary+Flattening.swift
+++ b/JustLog/Extensions/Dictionary+Flattening.swift
@@ -30,14 +30,22 @@ extension Dictionary where Key == String {
                  is Double,
                  is Bool:
                 retVal.updateValue(v, forKey: k)
-            case is Dictionary:
-                let inner = (v as! [String : Any]).flattened()
-                retVal = retVal.merged(with: inner)
+            case is [String : Any]:
+                if let value: [String : Any] = v as? [String : Any] {
+                    let inner = value.flattened()
+                    retVal = retVal.merged(with: inner)
+                }
+                else {
+                    continue
+                }
             case is Array<Any>:
                 retVal.updateValue(String(describing: v), forKey: k)
             case is NSError:
                 if let inner = v as? NSError, let userInfo: [String: Any] = inner.userInfo as? [String : Any] {
                     retVal = retVal.merged(with: userInfo.flattened())
+                }
+                else {
+                    continue
                 }
             default:
                 continue
@@ -66,11 +74,12 @@ extension Dictionary where Key == String {
     }
     
     private func mergeDictionariesByGroupingValues(_ dictionary: [String : Any], with dictionary2: [String : Any]) -> [String : Any] {
-        var retVal: [String : Any] = [:]
+        var retVal = dictionary
         dictionary2.forEach { (key, value) in
             if let value1 = dictionary[key] {
                 let mergedValue: [Any] = [value1, value]
-                retVal.updateValue(mergedValue, forKey: key)
+                let flattenedArray = mergedValue.flattened()
+                retVal.updateValue(flattenedArray, forKey: key)
             }
             else {
                 retVal.updateValue(value, forKey: key)
@@ -78,4 +87,23 @@ extension Dictionary where Key == String {
         }
         return retVal
     }
+    
+   }
+
+extension Array where Element == Any {
+    
+    func flattened() -> [Any] {
+        var arraythings: [Any] = []
+        for thing in self {
+            switch thing {
+            case is [Any]:
+               let arrayThing = thing as! [Any]
+               arraythings.append(contentsOf: arrayThing.flattened())
+            default:
+               arraythings.append(thing)
+            }
+        }
+        return arraythings
+    }
+
 }

--- a/JustLog/Extensions/Dictionary+Flattening.swift
+++ b/JustLog/Extensions/Dictionary+Flattening.swift
@@ -92,17 +92,17 @@ extension Dictionary where Key == String {
 extension Array where Element == Any {
     
     func flattened() -> [Any] {
-        var arraythings: [Any] = []
-        for thing in self {
-            switch thing {
+        var flattenedArray: [Any] = []
+        for element in self {
+            switch element {
             case is [Any]:
-               let arrayThing = thing as! [Any]
-               arraythings.append(contentsOf: arrayThing.flattened())
+               let elementsArray = element as! [Any]
+               flattenedArray.append(contentsOf: elementsArray.flattened())
             default:
-               arraythings.append(thing)
+               flattenedArray.append(element)
             }
         }
-        return arraythings
+        return flattenedArray
     }
     
 

--- a/JustLog/Extensions/Dictionary+JSON.swift
+++ b/JustLog/Extensions/Dictionary+JSON.swift
@@ -10,6 +10,9 @@ import Foundation
 
 extension Dictionary {
     
+    /// Parses the dictionary as a json data object and returns the String representation.
+    ///
+    /// - Returns: The String representation of the dictionary
     func toJSON() -> String? {
         
         var json: String? = nil

--- a/JustLog/Extensions/NSError+Readability.swift
+++ b/JustLog/Extensions/NSError+Readability.swift
@@ -10,6 +10,10 @@ import Foundation
 
 extension NSError {
     
+    
+    /// Parses Data values in the user info key as String and recursively does the same to all associated underying errors.
+    ///
+    /// - Returns: A copy of the error including 
     func humanReadableError() -> NSError {
         
         var flattenedUserInfo = userInfo
@@ -27,29 +31,7 @@ extension NSError {
             default:
                 continue
             }
-            
         }
-        
         return NSError(domain: domain, code: code, userInfo: flattenedUserInfo)
-
     }
-    
-    func underlyingErrors() -> [NSError] {
-        guard let underError = self.userInfo[NSUnderlyingErrorKey] as? NSError else {
-            return []
-        }
-        
-        return [underError] + underError.underlyingErrors()
-    }
-    
-    func errorChain() -> [NSError] {
-        
-        guard let underError = self.userInfo[NSUnderlyingErrorKey] as? NSError else {
-            return [self]
-        }
-        
-        return [self] + underError.errorChain()
-    }
-
-    
 }

--- a/JustLog/Extensions/NSError+Readability.swift
+++ b/JustLog/Extensions/NSError+Readability.swift
@@ -21,13 +21,12 @@ extension NSError {
         for (key, value) in userInfo {
             
             switch (value) {
-            case is String:
-                flattenedUserInfo[key] = value
-            case is Data:
-                flattenedUserInfo[key] = String(data: value as! Data, encoding: String.Encoding.utf8)
-            case is NSError:
-                let innerErr = value as! NSError
-                flattenedUserInfo[key] = innerErr.humanReadableError()
+            case let string as String:
+                flattenedUserInfo[key] = string
+            case let data as Data:
+                flattenedUserInfo[key] = String(data: data, encoding: String.Encoding.utf8)
+            case let error as NSError:
+                flattenedUserInfo[key] = error.humanReadableError()
             default:
                 continue
             }

--- a/JustLog/Extensions/NSError+Readability.swift
+++ b/JustLog/Extensions/NSError+Readability.swift
@@ -35,12 +35,20 @@ extension NSError {
     }
     
     func underlyingErrors() -> [NSError] {
+        guard let underError = self.userInfo[NSUnderlyingErrorKey] as? NSError else {
+            return []
+        }
+        
+        return [underError] + underError.underlyingErrors()
+    }
+    
+    func errorChain() -> [NSError] {
         
         guard let underError = self.userInfo[NSUnderlyingErrorKey] as? NSError else {
             return [self]
         }
         
-        return [self] + underError.underlyingErrors()
+        return [self] + underError.errorChain()
     }
 
     

--- a/JustLog/Extensions/NSError+Readability.swift
+++ b/JustLog/Extensions/NSError+Readability.swift
@@ -34,4 +34,14 @@ extension NSError {
 
     }
     
+    func underlyingErrors() -> [NSError] {
+        
+        guard let underError = self.userInfo[NSUnderlyingErrorKey] as? NSError else {
+            return [self]
+        }
+        
+        return [self] + underError.underlyingErrors()
+    }
+
+    
 }

--- a/JustLog/Extensions/NSError+UnderlyingErrors.swift
+++ b/JustLog/Extensions/NSError+UnderlyingErrors.swift
@@ -13,11 +13,11 @@ extension NSError {
     ///
     /// - Returns: An Array<NSError> with all the underlying errors excluding self
     func underlyingErrors() -> [NSError] {
-        guard let underError = self.userInfo[NSUnderlyingErrorKey] as? NSError else {
+        guard let underlyingError = self.userInfo[NSUnderlyingErrorKey] as? NSError else {
             return []
         }
         
-        return [underError] + underError.underlyingErrors()
+        return [underlyingError] + underlyingError.underlyingErrors()
     }
     
     /// Extracts and returns all the errors under the NSUnderlyingErrorKey, recursively.
@@ -25,11 +25,11 @@ extension NSError {
     /// - Returns: An Array<NSError> with all the underlying errors including self
     func errorChain() -> [NSError] {
         
-        guard let underError = self.userInfo[NSUnderlyingErrorKey] as? NSError else {
+        guard let underlyingError = self.userInfo[NSUnderlyingErrorKey] as? NSError else {
             return [self]
         }
         
-        return [self] + underError.errorChain()
+        return [self] + underlyingError.errorChain()
     }
     
     /// Extracts and returns all the errors under the NSUnderlyingErrorKey, recursively.
@@ -38,7 +38,7 @@ extension NSError {
     /// - Returns: An Array<NSError> with all the underlying errors including self after it disassociates the connected errors.
     func disassociatedErrorChain() -> [NSError] {
         
-        guard let underError = self.userInfo[NSUnderlyingErrorKey] as? NSError else {
+        guard let underlyingError = self.userInfo[NSUnderlyingErrorKey] as? NSError else {
             return [self]
         }
         
@@ -46,6 +46,6 @@ extension NSError {
         userInfoCopy.removeValue(forKey: NSUnderlyingErrorKey)
         let copyOfSelf = NSError(domain: self.domain, code: self.code, userInfo: userInfoCopy)
         
-        return [copyOfSelf] + underError.disassociatedErrorChain()
+        return [copyOfSelf] + underlyingError.disassociatedErrorChain()
     }
 }

--- a/JustLog/Extensions/NSError+UnderlyingErrors.swift
+++ b/JustLog/Extensions/NSError+UnderlyingErrors.swift
@@ -1,0 +1,51 @@
+//
+//  NSError+UnderlyingErrors.swift
+//  Pods
+//
+//  Created by Alkiviadis Papadakis on 22/08/2017.
+//
+//
+
+import Foundation
+extension NSError {
+    
+    /// Extracts and returns all the errors under the NSUnderlyingErrorKey, recursively.
+    ///
+    /// - Returns: An Array<NSError> with all the underlying errors excluding self
+    func underlyingErrors() -> [NSError] {
+        guard let underError = self.userInfo[NSUnderlyingErrorKey] as? NSError else {
+            return []
+        }
+        
+        return [underError] + underError.underlyingErrors()
+    }
+    
+    /// Extracts and returns all the errors under the NSUnderlyingErrorKey, recursively.
+    ///
+    /// - Returns: An Array<NSError> with all the underlying errors including self
+    func errorChain() -> [NSError] {
+        
+        guard let underError = self.userInfo[NSUnderlyingErrorKey] as? NSError else {
+            return [self]
+        }
+        
+        return [self] + underError.errorChain()
+    }
+    
+    /// Extracts and returns all the errors under the NSUnderlyingErrorKey, recursively.
+    /// after extracting an error, it creates a copy of it self by removing the NSUnderlyingErrorKey key.
+    ///
+    /// - Returns: An Array<NSError> with all the underlying errors including self after it disassociates the connected errors.
+    func disassociatedErrorChain() -> [NSError] {
+        
+        guard let underError = self.userInfo[NSUnderlyingErrorKey] as? NSError else {
+            return [self]
+        }
+        
+        var userInfoCopy = self.userInfo
+        userInfoCopy.removeValue(forKey: NSUnderlyingErrorKey)
+        let copyOfSelf = NSError(domain: self.domain, code: self.code, userInfo: userInfoCopy)
+        
+        return [copyOfSelf] + underError.disassociatedErrorChain()
+    }
+}

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ let logger = Logger.shared
 
 // file destination
 logger.logFilename = "justeat-demo.log"
-// logger configuration
-logger.loggingPolicy = .signleEvent
+
 // logstash destination
 logger.logstashHost = "my.logstash.endpoint.com"
 logger.logstashPort = 3515
@@ -77,15 +76,13 @@ logger.logLogstashSocketActivity = true
 
 // default info
 logger.defaultUserInfo = ["app": "my iOS App",
-"environment": "production",
-"tenant": "UK",
-"sessionID": someSessionID]
+                          "environment": "production",
+                          "tenant": "UK",
+                          "sessionID": someSessionID]
 logger.setup()
 ```
 
 The `defaultUserInfo` dictionary contains a set of basic information to add to every log. 
-
-The `loggingPolicy` allows for NSErrors associated under the `NSUnderlyingErrorKey` to be send either as a single event or as multiple events for every underlying error.
 
 The Logger class exposes 5 functions for the different types of logs. The only required parameter is the message, optional error and userInfo can be provided. Here are some examples of sending logs to JustLog:
 
@@ -111,30 +108,34 @@ The Logger unifies the information from `message`, `error`, `error.userInfo`, `u
 
 ```json
 {
-"message": ...,
-"userInfo": {
-"customKey": "CustomValue",
-"errors": [
-{
-"error_domain" : "com.domain",
-"error_code" : "1234",
-"NSLocalizedDescription": ...,
-"NSLocalizedFailureReasonError": ...,
-...
-},
-{
-"error_domain" : "com.domain.inner",
-"error_code" : "5678",
-"NSLocalizedDescription": ...,
-"NSLocalizedFailureReasonError": ...,
-...
-}],  
-"metadata": {
-"file": ...,
-"function": ...,
-"line": ...,
-...
-}
+  "message": "the log message",
+  "user_info": {
+    "app": "my iOS App",
+    "environment": "production",
+    "custom_key": "some custom value",
+    ...
+  },
+  "errors": [
+  {
+    "error_domain" : "com.domain",
+    "error_code" : "1234",
+    "NSLocalizedDescription": ...,
+    "NSLocalizedFailureReasonError": ...,
+    ...
+  },
+  {
+    "errorDomain" : "com.domain.inner",
+    "errorCode" : "5678",
+    "NSLocalizedDescription": ...,
+    "NSLocalizedFailureReasonError": ...,
+    ...
+  }],  
+  "metadata": {
+    "file": ...,
+    "function": ...,
+    "line": ...,
+    ...
+  }
 }
 
 ```
@@ -162,11 +163,11 @@ The console prints only the message.
 On file we store all the log info in the 'aggregated form'. 
 
 ```json
-2016-12-24 12:31:02.734  📣 VERBOSE: {"metadata":{"file":"ViewController.swift","app_version":"1.0 (1)","version":"10.1","function":"verbose()","device":"x86_64","line":"15"},"userInfo":{"environment":"production","app":"my iOS App","log_type":"verbose","tenant":"UK"},"message":"not so important"}
-2016-12-24 12:31:36.777  📝 DEBUG: {"metadata":{"file":"ViewController.swift","app_version":"1.0 (1)","version":"10.1","function":"debug()","device":"x86_64","line":"19"},"userInfo":{"environment":"production","app":"my iOS App","log_type":"debug","tenant":"UK"},"message":"something to debug"}
-2016-12-24 12:31:37.368  ℹ️ INFO: {"metadata":{"file":"ViewController.swift","app_version":"1.0 (1)","version":"10.1","function":"info()","device":"x86_64","line":"23"},"userInfo":{"environment":"production","app":"my iOS App","log_type":"info","tenant":"UK","some key":"some extra info"},"message":"a nice information"}
-2016-12-24 12:31:37.884  ⚠️ WARNING: {"metadata":{"file":"ViewController.swift","app_version":"1.0 (1)","version":"10.1","function":"warning()","device":"x86_64","line":"27"},"userInfo":{"environment":"production","app":"my iOS App","log_type":"warning","tenant":"UK","some key":"some extra info"},"message":"oh no, that won’t be good"}
-2016-12-24 12:31:38.475  ☠️ ERROR: {"metadata":{"file":"ViewController.swift","app_version":"1.0 (1)","version":"10.1","function":"error()","device":"x86_64","line":"47"},"userInfo":{"error_code":1234,"environment":"production","error_domain":"com.just-eat.test","log_type":"error","some key":"some extra info","NSLocalizedDescription":"description","NSLocalizedRecoverySuggestion":"recovery suggestion","app":"my iOS App","tenant":"UK","NSLocalizedFailureReason":"error value"},"message":"ouch, an error did occur!"}
+2016-12-24 12:31:02.734  📣 VERBOSE: {"metadata":{"file":"ViewController.swift","app_version":"1.0 (1)","version":"10.1","function":"verbose()","device":"x86_64","line":"15"},"user_info":{"environment":"production","app":"my iOS App","log_type":"verbose","tenant":"UK"},"message":"not so important"}
+2016-12-24 12:31:36.777  📝 DEBUG: {"metadata":{"file":"ViewController.swift","app_version":"1.0 (1)","version":"10.1","function":"debug()","device":"x86_64","line":"19"},"user_info":{"environment":"production","app":"my iOS App","log_type":"debug","tenant":"UK"},"message":"something to debug"}
+2016-12-24 12:31:37.368  ℹ️ INFO: {"metadata":{"file":"ViewController.swift","app_version":"1.0 (1)","version":"10.1","function":"info()","device":"x86_64","line":"23"},"user_info":{"environment":"production","app":"my iOS App","log_type":"info","tenant":"UK","some key":"some extra info"},"message":"a nice information"}
+2016-12-24 12:31:37.884  ⚠️ WARNING: {"metadata":{"file":"ViewController.swift","app_version":"1.0 (1)","version":"10.1","function":"warning()","device":"x86_64","line":"27"},"user_info":{"environment":"production","app":"my iOS App","log_type":"warning","tenant":"UK","some key":"some extra info"},"message":"oh no, that won’t be good"}
+2016-12-24 12:31:38.475  ☠️ ERROR: {"metadata":{"file":"ViewController.swift","app_version":"1.0 (1)","version":"10.1","function":"error()","device":"x86_64","line":"47"},"user_info":{"environment":"production","log_type":"error","some key":"some extra info","app":"my iOS App","tenant":"UK","NSLocalizedFailureReason":"error value"},"errors":[{"error_code":1234,"error_domain":"com.just-eat.test","NSLocalizedDescription":"description","NSLocalizedRecoverySuggestion":"recovery suggestion"}],"message":"ouch, an error did occur!"}
 ```
 
 
@@ -176,26 +177,25 @@ Before sending a log to Logstash, the 'aggregated form' is flattened to a simple
 
 ```json
 {
-"message": "ouch, an error did occur!",
+  "message": "ouch, an error did occur!",
 
-"environment": "production",
-"log_type": "error",
-"version": "10.1",
-"app": "iOS UK app",
-"tenant": "UK",
-"app_version": "1.0 (1)",
-"device": "x86_64",
+  "environment": "production",
+  "log_type": "error",
+  "version": "10.1",
+  "app": "iOS UK app",
+  "tenant": "UK",
+  "app_version": "1.0 (1)",
+  "device": "x86_64",
 
-"file": "ViewController.swift",
-"function": "error()",
-"line": "47",
-"errors": [{
-"error_domain": "com.just-eat.test",
-"error_code": "1234",
-"NSLocalizedDescription": "description",
-"NSLocalizedFailureReason": "error value",
-"NSLocalizedRecoverySuggestion": "recovery suggestion"
-}]
+  "file": "ViewController.swift",
+  "function": "error()",
+  "line": "47",
+  "errors": [{
+    "error_domain": "com.just-eat.test",
+    "error_code": "1234",
+    "NSLocalizedDescription": "description",
+    "NSLocalizedFailureReason": "error value"
+  }]
 }
 ```
 
@@ -231,26 +231,26 @@ or, more generally, in the `applicationDidEnterBackground` and `applicationWillT
 
 ```swift
 func applicationDidEnterBackground(_ application: UIApplication) {
-forceSendLogs(application)
+  forceSendLogs(application)
 }
 
 func applicationWillTerminate(_ application: UIApplication) {
-forceSendLogs(application)
+  forceSendLogs(application)
 }
 
 private func forceSendLogs(_ application: UIApplication) {
 
-var identifier: UIBackgroundTaskIdentifier = 0
+  var identifier: UIBackgroundTaskIdentifier = 0
 
-identifier = application.beginBackgroundTask(expirationHandler: {
-application.endBackgroundTask(identifier)
-identifier = UIBackgroundTaskInvalid
-})
+  identifier = application.beginBackgroundTask(expirationHandler: {
+    application.endBackgroundTask(identifier)
+    identifier = UIBackgroundTaskInvalid
+  })
 
-Logger.shared.forceSend { completionHandler in
-application.endBackgroundTask(identifier)
-identifier = UIBackgroundTaskInvalid
-}
+  Logger.shared.forceSend { completionHandler in
+    application.endBackgroundTask(identifier)
+    identifier = UIBackgroundTaskInvalid
+  }
 }
 ```
 


### PR DESCRIPTION
This PR add supports to log error chains (created via the usage of the user info key `NSUnderlyingErrorKey`). Errors are now flattened out and put in the `errors` key of the log representation. 