### PR TITLE
Swift 4 compatibility

### DIFF
--- a/JustLog/Classes/LogstashDestination.swift
+++ b/JustLog/Classes/LogstashDestination.swift
@@ -90,7 +90,10 @@ public class LogstashDestination: BaseDestination  {
     
     func addLog(_ dict: [String: Any]) {
         let time = mach_absolute_time()
-        let logTag = Int(truncatingBitPattern: time)
+        #if swift(>=4.0)
+            let logTag = Int(truncatingIfNeeded: time)
+        #else
+            let logTag = Int(truncatingBitPattern: time)
         logsToShip[logTag] = dict
     }
     

--- a/JustLog/Classes/LogstashDestination.swift
+++ b/JustLog/Classes/LogstashDestination.swift
@@ -94,6 +94,7 @@ public class LogstashDestination: BaseDestination  {
             let logTag = Int(truncatingIfNeeded: time)
         #else
             let logTag = Int(truncatingBitPattern: time)
+        #endif
         logsToShip[logTag] = dict
     }
     


### PR DESCRIPTION
After update to Xcode 9 (non-beta), I was having issues with using of `Int.init(truncatingBitPattern:)`. I fixed it in similar way to [SwiftyBeaver](https://github.com/SwiftyBeaver/SwiftyBeaver/blob/master/Sources/AES256CBC.swift#L54)