### PR TITLE
TLS evaluate trust improvements

### DIFF
--- a/Example/JustLog/AppDelegate.swift
+++ b/Example/JustLog/AppDelegate.swift
@@ -61,14 +61,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         logger.logstashPort = 5052
         logger.logstashTimeout = 5
         logger.logLogstashSocketActivity = true
-        // change this in case of self-signed certificate on server side
-        logger.isTrustedServer = true
-        logger.didReceiveTrustHandler = { _, _, completionHandler in
-            completionHandler(true)
-        }
 
         // logz.io support
         //logger.logzioToken = <logzioToken>
+
+        // untrusted (self-signed) logstash server support
+        //logger.allowUntrustedServer = <Bool>
         
         // default info
         logger.defaultUserInfo = ["application": "JustLog iOS Demo",

--- a/Example/JustLog/AppDelegate.swift
+++ b/Example/JustLog/AppDelegate.swift
@@ -61,9 +61,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         logger.logstashPort = 5052
         logger.logstashTimeout = 5
         logger.logLogstashSocketActivity = true
-        logger.isTrustedServer = false
+        // change this in case of self-signed certificate on server side
+        logger.isTrustedServer = true
         logger.didReceiveTrustHandler = { _, _, completionHandler in
-            completionHandler(false)
+            completionHandler(true)
         }
 
         // logz.io support

--- a/Example/JustLog/AppDelegate.swift
+++ b/Example/JustLog/AppDelegate.swift
@@ -61,6 +61,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         logger.logstashPort = 5052
         logger.logstashTimeout = 5
         logger.logLogstashSocketActivity = true
+        logger.isTrustedServer = false
+        logger.didReceiveTrustHandler = { _, _, completionHandler in
+            completionHandler(false)
+        }
 
         // logz.io support
         //logger.logzioToken = <logzioToken>

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import SwiftyBeaver
-import CocoaAsyncSocket
 
 @objcMembers
 public final class Logger: NSObject {
@@ -45,18 +44,12 @@ public final class Logger: NSObject {
     public var logstashTimeout: TimeInterval = 20
     public var logLogstashSocketActivity: Bool = false
     public var logzioToken: String?
-    /**
-     Default to true, set it to false whenever manual security evaluation handling is needed.
-
-     - Note: if `false`, then `didReceiveTrustHandler` must be set or the connection will be rejected
-     */
-    public var isTrustedServer:Bool = true
 
     /**
-     Set it to manually handle the security evaluation.
+     Default to `false`, if `true` untrusted certificates (as self-signed are) will be trusted
      */
-    public var didReceiveTrustHandler:((GCDAsyncSocket, SecTrust, (Bool) -> Void) -> Void)?
-    
+    public var allowUntrustedServer: Bool = false
+
     // logger conf
     public var defaultUserInfo: [String : Any]?
     public var enableConsoleLogging: Bool = true
@@ -98,8 +91,7 @@ public final class Logger: NSObject {
         
         // logstash
         if enableLogstashLogging {
-            logstash = LogstashDestination(host: logstashHost, port: logstashPort, timeout: logstashTimeout, logActivity: logLogstashSocketActivity, isTrustedServer: self.isTrustedServer)
-            logstash.didReceiveTrustHandler = self.didReceiveTrustHandler
+            logstash = LogstashDestination(host: logstashHost, port: logstashPort, timeout: logstashTimeout, logActivity: logLogstashSocketActivity, allowUntrustedServer: allowUntrustedServer)
             logstash.logzioToken = logzioToken
             internalLogger.addDestination(logstash)
         }

--- a/JustLog/Classes/LogstashDestination.swift
+++ b/JustLog/Classes/LogstashDestination.swift
@@ -13,7 +13,6 @@ import CocoaAsyncSocket
 public class LogstashDestination: BaseDestination  {
     
     public var logzioToken: String?
-    public var didReceiveTrustHandler:((GCDAsyncSocket, SecTrust, (Bool) -> Void) -> Void)?
     
     var logsToShip = [Int : [String : Any]]()
     fileprivate var completionHandler: ((_ error: Error?) -> Void)?
@@ -28,11 +27,11 @@ public class LogstashDestination: BaseDestination  {
         fatalError()
     }
     
-    public required init(host: String, port: UInt16, timeout: TimeInterval, logActivity: Bool, isTrustedServer:Bool = true) {
+    public required init(host: String, port: UInt16, timeout: TimeInterval, logActivity: Bool, allowUntrustedServer: Bool) {
         super.init()
         self.logActivity = logActivity
         self.logDispatchQueue.maxConcurrentOperationCount = 1
-        self.socketManager = AsyncSocketManager(host: host, port: port, timeout: timeout, delegate: self, logActivity: logActivity, isTrustedServer: isTrustedServer)
+        self.socketManager = AsyncSocketManager(host: host, port: port, timeout: timeout, delegate: self, logActivity: logActivity, allowUntrustedServer: allowUntrustedServer)
     }
     
     deinit {
@@ -117,16 +116,6 @@ public class LogstashDestination: BaseDestination  {
 // MARK: - GCDAsyncSocketManager Delegate
 
 extension LogstashDestination: AsyncSocketManagerDelegate {
-    func socket(_ socket: GCDAsyncSocket, didReceiveTrust trust: SecTrust, completionHandler: (Bool) -> Void) {
-        // this method should be called only when the caller choose to manually handle the security evaluation.
-        // in that case `didReceiveTrustHandler` must have a value. If it doesn't let's reject the evaluation
-        guard let didReceiveTrustHandler = self.didReceiveTrustHandler else {
-            completionHandler(false)
-            return
-        }
-        didReceiveTrustHandler(socket, trust, completionHandler)
-    }
-
     
     func socket(_ socket: GCDAsyncSocket, didWriteDataWithTag tag: Int) {
         logDispatchQueue.addOperation {

--- a/JustLog/Classes/LogstashDestination.swift
+++ b/JustLog/Classes/LogstashDestination.swift
@@ -27,7 +27,7 @@ public class LogstashDestination: BaseDestination  {
         fatalError()
     }
     
-    public required init(host: String, port: UInt16, timeout: TimeInterval, logActivity: Bool, allowUntrustedServer: Bool) {
+    public required init(host: String, port: UInt16, timeout: TimeInterval, logActivity: Bool, allowUntrustedServer: Bool = false) {
         super.init()
         self.logActivity = logActivity
         self.logDispatchQueue.maxConcurrentOperationCount = 1


### PR DESCRIPTION
Hi guys,

I noticed that the DI for the TLS security evaluation was not respected and `self.socket.startTLS([String(kCFStreamSSLPeerName): NSString(string: host)])` was hardcoded.

In my use case, when testing the app in develop environment, our ELK server uses a self-signed certificate, therefore the connection was pending.

The changes in this PR don't break the backward compatibility and add the chance to inject a closure in which handle the not trusted server (or even a trusted one).

Only bit I don't like: if the `AppDelegate`, in Example, wanted to use somehow the passed in `GCDAsyncSocket` it would need to import `CocoaAsyncSocket`, that's not ideal. But I could live with that.

If you have any way out of this, or any thought about the PR, please let me know, happy to update my code. 

Alessandro