### PR TITLE
Add an option to allow for unsecure socket

### DIFF
--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -50,6 +50,11 @@ public final class Logger: NSObject {
      */
     public var allowUntrustedServer: Bool = false
 
+    /**
+     Default to `false`, if `true` ssl is not required for socket 
+     */
+    public var useSecureSocket: Bool = true
+
     // logger conf
     public var defaultUserInfo: [String : Any]?
     public var enableConsoleLogging: Bool = true
@@ -91,7 +96,7 @@ public final class Logger: NSObject {
         
         // logstash
         if enableLogstashLogging {
-            logstash = LogstashDestination(host: logstashHost, port: logstashPort, timeout: logstashTimeout, logActivity: logLogstashSocketActivity, allowUntrustedServer: allowUntrustedServer)
+            logstash = LogstashDestination(host: logstashHost, port: logstashPort, timeout: logstashTimeout, logActivity: logLogstashSocketActivity, useSecureSocket: useSecureSocket, allowUntrustedServer: allowUntrustedServer)
             logstash.logzioToken = logzioToken
             internalLogger.addDestination(logstash)
         }

--- a/JustLog/Classes/LogstashDestination.swift
+++ b/JustLog/Classes/LogstashDestination.swift
@@ -27,11 +27,11 @@ public class LogstashDestination: BaseDestination  {
         fatalError()
     }
     
-    public required init(host: String, port: UInt16, timeout: TimeInterval, logActivity: Bool, allowUntrustedServer: Bool = false) {
+    public required init(host: String, port: UInt16, timeout: TimeInterval, logActivity: Bool, useSecureSocket: Bool = true, allowUntrustedServer: Bool = false) {
         super.init()
         self.logActivity = logActivity
         self.logDispatchQueue.maxConcurrentOperationCount = 1
-        self.socketManager = AsyncSocketManager(host: host, port: port, timeout: timeout, delegate: self, logActivity: logActivity, allowUntrustedServer: allowUntrustedServer)
+        self.socketManager = AsyncSocketManager(host: host, port: port, timeout: timeout, delegate: self, logActivity: logActivity, useSecureSocket: useSecureSocket, allowUntrustedServer: allowUntrustedServer)
     }
     
     deinit {
@@ -131,6 +131,12 @@ extension LogstashDestination: AsyncSocketManagerDelegate {
     
     func socketDidSecure(_ socket: GCDAsyncSocket) {
         self.writeLogs()
+    }
+    
+    func socket(_ sock: GCDAsyncSocket, didConnectToHost host: String, port: UInt16) {
+        if !self.socketManager.useSecureSocket {
+            self.writeLogs()
+        }
     }
     
     func socket(_ socket: GCDAsyncSocket, didDisconnectWithError error: Error?) {


### PR DESCRIPTION
I had trouble setting up a Logstash instance with a self-signed certificate just for debugging and figured it would be simpler just to skip this entirely and edit JustLog.

So, this PR add an option called `useSecureSocket` which default to true to allow the use of unsecure socket.