### PR TITLE
Upgrade to Swift 5 & Xcode 10.2. Upgrade SwiftyBeaver to 1.7.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "SwiftyBeaver/SwiftyBeaver" ~> 1.6.1
+github "SwiftyBeaver/SwiftyBeaver" ~> 1.7.0
 github "robbiehanson/CocoaAsyncSocket" ~> 7.6.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "SwiftyBeaver/SwiftyBeaver" "1.6.1"
+github "SwiftyBeaver/SwiftyBeaver" "1.7.0"
 github "robbiehanson/CocoaAsyncSocket" "7.6.3"

--- a/Example/JustLog.xcodeproj/project.pbxproj
+++ b/Example/JustLog.xcodeproj/project.pbxproj
@@ -225,23 +225,23 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 					};
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
 				};
 			};
 			buildConfigurationList = 607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "JustLog" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -321,7 +321,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-JustLog_Example/Pods-JustLog_Example-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-JustLog_Example/Pods-JustLog_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CocoaAsyncSocket/CocoaAsyncSocket.framework",
 				"${BUILT_PRODUCTS_DIR}/JustLog/JustLog.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyBeaver/SwiftyBeaver.framework",
@@ -334,7 +334,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-JustLog_Example/Pods-JustLog_Example-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-JustLog_Example/Pods-JustLog_Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -397,6 +397,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -455,6 +456,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -512,6 +514,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -525,6 +528,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -544,6 +548,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/JustLog_Example.app/JustLog_Example";
 			};
 			name = Debug;
@@ -560,6 +565,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/JustLog_Example.app/JustLog_Example";
 			};
 			name = Release;

--- a/Example/JustLog.xcodeproj/xcshareddata/xcschemes/JustLog-Example.xcscheme
+++ b/Example/JustLog.xcodeproj/xcshareddata/xcschemes/JustLog-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -42,7 +42,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FDEB41665571893A594DFEE6919B8C35"
+               BlueprintIdentifier = "A017506CB605B3FF53C4219293B17F0E"
                BuildableName = "Pods_JustLog_Example.framework"
                BlueprintName = "Pods-JustLog_Example"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - CocoaAsyncSocket (7.6.3)
-  - JustLog (2.5.0):
+  - JustLog (2.5.1):
     - CocoaAsyncSocket (~> 7.6.3)
-    - SwiftyBeaver (~> 1.6.1)
-  - SwiftyBeaver (1.6.1)
+    - SwiftyBeaver (~> 1.7.0)
+  - SwiftyBeaver (1.7.0)
 
 DEPENDENCIES:
   - JustLog (from `../`)
@@ -19,9 +19,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CocoaAsyncSocket: eafaa68a7e0ec99ead0a7b35015e0bf25d2c8987
-  JustLog: 48d7d85c02de3eb736e02bbac9ff7a879fa8921d
-  SwiftyBeaver: ccfcdf85a04d429f1633f668650b0ce8020bda3a
+  JustLog: 1a5b7a17e6a00fe89fa42fb5bed0bad915f05fb7
+  SwiftyBeaver: 4cc0080d2e23f980652e28978db11a5c9da39165
 
 PODFILE CHECKSUM: 7da834f2fa53812b1c2d4fd2279eab2d73e3f7c5
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.1

--- a/JustLog.podspec
+++ b/JustLog.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   
   s.source_files = 'JustLog/Classes/**/*', 'JustLog/Extensions/**/*'
 
-  s.dependency 'SwiftyBeaver', '~> 1.6.1'
+  s.dependency 'SwiftyBeaver', '~> 1.7.0'
   s.dependency 'CocoaAsyncSocket', '~> 7.6.3'
 
 end

--- a/JustLog.podspec
+++ b/JustLog.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'JustLog'
-  s.version          = '2.5.0'
+  s.version          = '2.5.1'
   s.summary          = 'JustLog brings logging on iOS to the next level. It supports console, file and remote Logstash logging via TCP socket with no effort.'
 
   s.description      = "<<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '10.0'
-  s.swift_version = '4.2'
+  s.swift_version = '5.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   
   s.source_files = 'JustLog/Classes/**/*', 'JustLog/Extensions/**/*'

--- a/JustLog.xcodeproj/project.pbxproj
+++ b/JustLog.xcodeproj/project.pbxproj
@@ -242,7 +242,7 @@
 					};
 					A60280F52065559400348BCE = {
 						CreatedOnToolsVersion = 9.2;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -253,6 +253,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = A60280EC2065559400348BCE;
 			productRefGroup = A60280F72065559400348BCE /* Products */;
@@ -515,7 +516,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.justeat.JustLog;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -540,7 +541,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.justeat.JustLog;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;


### PR DESCRIPTION
In order to use JustLog in Xcode 10.2 with Swift 5.0, the dependency of SwiftyBeaver needs to be upgraded. 

This PR upgrades:

* SwiftyBeaver to 1.7.0
* The Swift version to 5.0
* The project versions to Xcode 10.2

Also, I ran the tests and the example app with no issues.

