### PR TITLE
Increment minimum iOS version and decrement minimum TVOS version to 11.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,37 @@
-# OS X
+# OS X Finder
 .DS_Store
+UserInterfaceState.xcuserstate
 
-# Xcode
-build/
-*.pbxuser
-!default.pbxuser
+# Exclude personal Xcode user settings
+# Xcode per-user config
+*.mode1
 *.mode1v3
 !default.mode1v3
 *.mode2v3
 !default.mode2v3
+*.perspective
 *.perspectivev3
 !default.perspectivev3
-xcuserdata/
+*.pbxuser
+!default.pbxuser
+xcuserdata
 *.xccheckout
-profile
+*.xcsettings
 *.moved-aside
+
+# Xcode
+build/
 DerivedData
+profile
 *.hmap
 *.ipa
+
+# Automatic backup files
+*~.nib/
+*.swp
+*~
+*.dat
+*.dep
 
 # Bundler
 .bundle
@@ -30,7 +44,7 @@ Carthage/Build
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
-# 
+#
 # Note: if you ignore the Pods directory, make sure to uncomment
 # `pod install` in .travis.yml
 #

--- a/JustLog.xcodeproj/project.pbxproj
+++ b/JustLog.xcodeproj/project.pbxproj
@@ -351,6 +351,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TVOS_DEPLOYMENT_TARGET = 11.2;
 			};
 			name = Debug;
 		};
@@ -376,6 +377,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TVOS_DEPLOYMENT_TARGET = 11.2;
 			};
 			name = Release;
 		};
@@ -511,7 +513,7 @@
 				);
 				INFOPLIST_FILE = "JustLog/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.justeat.JustLog;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -536,7 +538,7 @@
 				);
 				INFOPLIST_FILE = "JustLog/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.justeat.JustLog;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/JustLog.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/JustLog.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/JustLog.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/JustLog.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
The minimum build version for the build target's dependencies are too low to build it with Carthage. Since the project's min OS version is set to 11.2 I modified it for the build targets as well and aligned them.

Furthermore I did some housekeeping by adding additional paths to the `.gitignore` file and due to this removed workspace files that are user specific.