### PR TITLE
Replace DispatchTimer with a wrapper

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - CocoaAsyncSocket (7.6.3)
-  - JustLog (3.0.4):
+  - JustLog (3.0.5):
     - CocoaAsyncSocket (~> 7.6.3)
     - SwiftyBeaver (~> 1.8.3)
   - SwiftyBeaver (1.8.3)
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CocoaAsyncSocket: eafaa68a7e0ec99ead0a7b35015e0bf25d2c8987
-  JustLog: da4a50ef1c3de5937a008e1a222a51da1a953547
+  JustLog: d583795da0ed7da3c4adcd76c28031d4043a3258
   SwiftyBeaver: 3d3e93a12d648bd400b6f2948a7ef128b5b183c7
 
 PODFILE CHECKSUM: 0682bc8f039b3897a7cc797e15668481c16d38a1

--- a/JustLog.podspec
+++ b/JustLog.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'JustLog'
-  s.version          = '3.0.4'
+  s.version          = '3.0.5'
   s.summary          = 'JustLog brings logging on iOS to the next level. It supports console, file and remote Logstash logging via TCP socket with no effort.'
 
   s.description      = "<<-DESC

--- a/JustLog.xcodeproj/project.pbxproj
+++ b/JustLog.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		A6028123206555D000348BCE /* UIDevice+Info.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6028113206555D000348BCE /* UIDevice+Info.swift */; };
 		A60281282065560F00348BCE /* CocoaAsyncSocket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A60281262065560F00348BCE /* CocoaAsyncSocket.framework */; };
 		A60281292065560F00348BCE /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A60281272065560F00348BCE /* SwiftyBeaver.framework */; };
+		ADF64E12248E3F4A0097C92F /* RepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF64E11248E3F4A0097C92F /* RepeatingTimer.swift */; };
+		ADF64E13248E3F4A0097C92F /* RepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF64E11248E3F4A0097C92F /* RepeatingTimer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -64,6 +66,7 @@
 		A6028113206555D000348BCE /* UIDevice+Info.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIDevice+Info.swift"; sourceTree = "<group>"; };
 		A60281262065560F00348BCE /* CocoaAsyncSocket.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaAsyncSocket.framework; path = Carthage/Build/iOS/CocoaAsyncSocket.framework; sourceTree = "<group>"; };
 		A60281272065560F00348BCE /* SwiftyBeaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyBeaver.framework; path = Carthage/Build/iOS/SwiftyBeaver.framework; sourceTree = "<group>"; };
+		ADF64E11248E3F4A0097C92F /* RepeatingTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatingTimer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,6 +136,7 @@
 				A6028108206555D000348BCE /* Logger.swift */,
 				A6028109206555D000348BCE /* Logging.swift */,
 				A602810A206555D000348BCE /* LogstashDestination.swift */,
+				ADF64E11248E3F4A0097C92F /* RepeatingTimer.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -292,6 +296,7 @@
 				4D2F04F920DD2FF9004286A7 /* NSError+UnderlyingErrors.swift in Sources */,
 				4D2F04FA20DD2FF9004286A7 /* String+Conversion.swift in Sources */,
 				4D2F04FB20DD2FF9004286A7 /* ConsoleDestination.swift in Sources */,
+				ADF64E13248E3F4A0097C92F /* RepeatingTimer.swift in Sources */,
 				4D2F04FC20DD2FF9004286A7 /* Logging.swift in Sources */,
 				4D2F04FD20DD2FF9004286A7 /* FileDestination.swift in Sources */,
 				4D2F04FE20DD2FF9004286A7 /* Dictionary+Flattening.swift in Sources */,
@@ -313,6 +318,7 @@
 				A6028121206555D000348BCE /* NSError+UnderlyingErrors.swift in Sources */,
 				A6028122206555D000348BCE /* String+Conversion.swift in Sources */,
 				A6028117206555D000348BCE /* ConsoleDestination.swift in Sources */,
+				ADF64E12248E3F4A0097C92F /* RepeatingTimer.swift in Sources */,
 				A602811A206555D000348BCE /* Logging.swift in Sources */,
 				A6028118206555D000348BCE /* FileDestination.swift in Sources */,
 				A602811D206555D000348BCE /* Dictionary+Flattening.swift in Sources */,

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -109,7 +109,7 @@ public final class Logger: NSObject {
                 self.cancelSending()
             }
             
-            timer?.resume()
+            timer?.run()
         }
     }
     

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -58,8 +58,8 @@ public final class Logger: NSObject {
     public var baseUrlForFileLogging = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
     public let internalLogger = SwiftyBeaver.self
     
-    private var dispatchInterval: Int = 5
-    private var dispatchTimer: DispatchSourceTimer?
+    private var timerInterval: TimeInterval = 5
+    private var timer: RepeatingTimer?
     
     // destinations
     public var console: ConsoleDestination!
@@ -67,8 +67,8 @@ public final class Logger: NSObject {
     public var file: FileDestination!
     
     deinit {
-        dispatchTimer?.cancel()
-        dispatchTimer = nil
+        timer?.suspend()
+        timer = nil
     }
     
     public func setup() {
@@ -98,20 +98,18 @@ public final class Logger: NSObject {
             logstash.logzioToken = logzioToken
             internalLogger.addDestination(logstash)
             
-            dispatchTimer = DispatchSource.makeTimerSource(flags: [], queue: .main)
-            dispatchTimer?.setEventHandler(handler: { [weak self] in
+            timer = RepeatingTimer(timeInterval: timerInterval)
+            timer?.eventHandler = { [weak self] in
                 guard let self = self else { return }
                 self.forceSend()
-            })
-            dispatchTimer?.setCancelHandler(handler: { [weak self] in
+            }
+            
+            timer?.cancelHandler = { [weak self] in
                 guard let self = self else { return }
                 self.cancelSending()
-            })
-            let dispatchTimeInterval = DispatchTimeInterval.seconds(dispatchInterval)
-            dispatchTimer?.schedule(deadline: DispatchTime.now(),
-                                    repeating: dispatchTimeInterval,
-                                    leeway: dispatchTimeInterval)
-            dispatchTimer?.activate()
+            }
+            
+            timer?.resume()
         }
     }
     

--- a/JustLog/Classes/RepeatingTimer.swift
+++ b/JustLog/Classes/RepeatingTimer.swift
@@ -5,6 +5,7 @@
 //  Created by Junaid Younus on 08/06/2020.
 //  Copyright © 2020 Just Eat. All rights reserved.
 //
+//  https://medium.com/over-engineering/a-background-repeating-timer-in-swift-412cecfd2ef9 
 
 import Foundation
 

--- a/JustLog/Classes/RepeatingTimer.swift
+++ b/JustLog/Classes/RepeatingTimer.swift
@@ -36,7 +36,7 @@ internal class RepeatingTimer {
 
     private enum State {
         case suspended
-        case resumed
+        case running
     }
 
     private var state: State = .suspended
@@ -48,13 +48,13 @@ internal class RepeatingTimer {
          If the timer is suspended, calling cancel without resuming
          triggers a crash. This is documented here https://forums.developer.apple.com/thread/15902
          */
-        resume()
+        run()
         eventHandler = nil
     }
 
-    func resume() {
-        guard state != .resumed else { return }
-        state = .resumed
+    func run() {
+        guard state != .running else { return }
+        state = .running
         timer.resume()
     }
 

--- a/JustLog/Classes/RepeatingTimer.swift
+++ b/JustLog/Classes/RepeatingTimer.swift
@@ -1,0 +1,65 @@
+//
+//  RepeatingTimer.swift
+//  JustLog
+//
+//  Created by Junaid Younus on 08/06/2020.
+//  Copyright © 2020 Just Eat. All rights reserved.
+//
+
+import Foundation
+
+/// RepeatingTimer mimics the API of DispatchSourceTimer but in a way that prevents crashes that occur from calling resume multiple times on a timer that is
+/// already resumed (noted by https://github.com/SiftScience/sift-ios/issues/52)
+internal class RepeatingTimer {
+
+    let timeInterval: TimeInterval
+    
+    init(timeInterval: TimeInterval) {
+        self.timeInterval = timeInterval
+    }
+    
+    private lazy var timer: DispatchSourceTimer = {
+        let t = DispatchSource.makeTimerSource()
+        t.schedule(deadline: .now() + self.timeInterval, repeating: self.timeInterval)
+        t.setEventHandler(handler: { [weak self] in
+            self?.eventHandler?()
+        })
+        t.setCancelHandler(handler: { [weak self] in
+            self?.cancelHandler?()
+        })
+        return t
+    }()
+
+    var eventHandler: (() -> Void)?
+    var cancelHandler: (() -> Void)?
+
+    private enum State {
+        case suspended
+        case resumed
+    }
+
+    private var state: State = .suspended
+
+    deinit {
+        timer.setEventHandler {}
+        timer.cancel()
+        /*
+         If the timer is suspended, calling cancel without resuming
+         triggers a crash. This is documented here https://forums.developer.apple.com/thread/15902
+         */
+        resume()
+        eventHandler = nil
+    }
+
+    func resume() {
+        guard state != .resumed else { return }
+        state = .resumed
+        timer.resume()
+    }
+
+    func suspend() {
+        guard state != .suspended else { return }
+        state = .suspended
+        timer.suspend()
+    }
+}


### PR DESCRIPTION
This is a speculative fix for a crashing issue which we are seeing internally. It replaces the DispatchTimer with a wrapper, which takes care of some potential scenarios where the timer could lead to a crash.