### PR TITLE
Correct filtering out of non-serializable objects from error chain

### DIFF
--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -215,7 +215,7 @@ extension Logger {
         if let error = error {
             let errorDictionaries = error.disassociatedErrorChain()
                 .map { errorDictionary(for: $0) }
-                .filter { $0.values.allSatisfy { JSONSerialization.isValidJSONObject($0) } }
+                .filter { JSONSerialization.isValidJSONObject($0) }
             retVal[errorsConst] = errorDictionaries
         }
         


### PR DESCRIPTION
Correcting #87 as independent dictionary values accessed with `.values` don't validate with `JSONSerialization.isValidJSONObject` but the dictionary itself does. Go figure.