### PR TITLE
Duplicate logger destinations

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - JustLog (3.1.2):
+  - JustLog (3.1.3):
     - SwiftyBeaver (~> 1.9.1)
   - SwiftyBeaver (1.9.1)
 
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  JustLog: c4a398acec6d5ce3f5b85b8618f479ceb46fd9dd
+  JustLog: c1b12fe8fc6a7c22cc31dd874fe7776eaa7089d2
   SwiftyBeaver: a1f5691458561414bcfab51874b2b7445451602b
 
 PODFILE CHECKSUM: 0682bc8f039b3897a7cc797e15668481c16d38a1

--- a/JustLog.podspec
+++ b/JustLog.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'JustLog'
-  s.version          = '3.1.2'
+  s.version          = '3.1.3'
   s.summary          = 'JustLog brings logging on iOS to the next level. It supports console, file and remote Logstash logging via TCP socket with no effort.'
 
   s.description      = "<<-DESC

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -75,6 +75,8 @@ public final class Logger: NSObject {
         
         let format = "$Dyyyy-MM-dd HH:mm:ss.SSS$d $T $C$L$c: $M"
         
+        internalLogger.removeAllDestinations()
+        
         // console
         if enableConsoleLogging {
             console = JustLog.ConsoleDestination()


### PR DESCRIPTION
Logger setup wasn't clearing down existing log destinations when called, leading to some duplicate logging if setup was called multiple times.