### PR TITLE
Improve log message serialisation fallback. Log the failure

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - JustLog (3.1.3):
+  - JustLog (3.1.4):
     - SwiftyBeaver (~> 1.9.1)
   - SwiftyBeaver (1.9.1)
 
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  JustLog: c1b12fe8fc6a7c22cc31dd874fe7776eaa7089d2
+  JustLog: af67cd16027edcfc977d83add0668d1e269df737
   SwiftyBeaver: a1f5691458561414bcfab51874b2b7445451602b
 
 PODFILE CHECKSUM: 0682bc8f039b3897a7cc797e15668481c16d38a1

--- a/Example/Tests/NSError_ReadabilityTests.swift
+++ b/Example/Tests/NSError_ReadabilityTests.swift
@@ -67,4 +67,106 @@ class NSError_Flattening: XCTestCase {
         // Then
         XCTAssertEqual(expectedReadableError, readableError)
     }
+    
+    func test_GivenAnErrorUserInfoWithNSObject_WhenCallingHumanReadableError_ThenUserInfoContainsDescription() {
+        
+        // Given
+        let nsObjectKey = "UnreadableNSObjectKey"
+        let nsObjectValue:NSObject = NSURL(string: "https://just-eat.com")!
+        
+        let unreadableUserInfos = [
+            NSLocalizedFailureReasonErrorKey: "error value".data(using: String.Encoding.utf8)!,
+            NSLocalizedDescriptionKey: "description",
+            NSLocalizedRecoverySuggestionErrorKey: "recovery suggestion".data(using: String.Encoding.utf8)!,
+            nsObjectKey: nsObjectValue
+            ] as [String : Any]
+        
+        let readableUserInfos = [
+            NSLocalizedFailureReasonErrorKey: "error value",
+            NSLocalizedDescriptionKey: "description",
+            NSLocalizedRecoverySuggestionErrorKey: "recovery suggestion",
+            nsObjectKey: "https://just-eat.com"
+        ]
+        
+        let unreadableError = NSError(domain: "com.just-eat.test", code:1234, userInfo:unreadableUserInfos)
+        let expectedReadableError = NSError(domain: "com.just-eat.test", code:1234, userInfo:readableUserInfos)
+        
+        // When
+        let readableError = unreadableError.humanReadableError()
+        
+        // Then
+        XCTAssertEqual(expectedReadableError, readableError)
+    }
+    
+    func test_GivenAnErrorUserInfoWithCustomStringConvertible_WhenCallingHumanReadableError_ThenUserInfoContainsDescription() {
+        
+        // Given
+        enum ReadableEnum: CustomStringConvertible {
+            var description: String { "nonSerializable" }
+            
+            case nonSerializable
+        }
+        
+        let enumKey = "UnreadableEnumKey"
+        let enumValue: ReadableEnum = .nonSerializable
+        
+        let unreadableUserInfos = [
+            NSLocalizedFailureReasonErrorKey: "error value".data(using: String.Encoding.utf8)!,
+            NSLocalizedDescriptionKey: "description",
+            NSLocalizedRecoverySuggestionErrorKey: "recovery suggestion".data(using: String.Encoding.utf8)!,
+            enumKey: enumValue
+            ] as [String : Any]
+        
+        let readableUserInfos = [
+            NSLocalizedFailureReasonErrorKey: "error value",
+            NSLocalizedDescriptionKey: "description",
+            NSLocalizedRecoverySuggestionErrorKey: "recovery suggestion",
+            enumKey: "nonSerializable"
+        ]
+        
+        let unreadableError = NSError(domain: "com.just-eat.test", code:1234, userInfo:unreadableUserInfos)
+        let expectedReadableError = NSError(domain: "com.just-eat.test", code:1234, userInfo:readableUserInfos)
+        
+        // When
+        let readableError = unreadableError.humanReadableError()
+        
+        // Then
+        XCTAssertEqual(expectedReadableError, readableError)
+    }
+
+    
+    func test_GivenAnErrorUserInfoWithPlainSwiftObject_WhenCallingHumanReadableError_ThenUserInfoContainsDefaultMessage() {
+        
+        // Given
+        enum UnreadableEnum {
+            case nonSerializable
+        }
+        
+        let enumKey = "UnreadableEnumKey"
+        let enumValue: UnreadableEnum = .nonSerializable
+        
+        let unreadableUserInfos = [
+            NSLocalizedFailureReasonErrorKey: "error value".data(using: String.Encoding.utf8)!,
+            NSLocalizedDescriptionKey: "description",
+            NSLocalizedRecoverySuggestionErrorKey: "recovery suggestion".data(using: String.Encoding.utf8)!,
+            enumKey: enumValue
+            ] as [String : Any]
+        
+        let readableUserInfos = [
+            NSLocalizedFailureReasonErrorKey: "error value",
+            NSLocalizedDescriptionKey: "description",
+            NSLocalizedRecoverySuggestionErrorKey: "recovery suggestion",
+            enumKey: "The value for key 'UnreadableEnumKey' can't be serialised"
+        ]
+        
+        let unreadableError = NSError(domain: "com.just-eat.test", code:1234, userInfo:unreadableUserInfos)
+        let expectedReadableError = NSError(domain: "com.just-eat.test", code:1234, userInfo:readableUserInfos)
+        
+        // When
+        let readableError = unreadableError.humanReadableError()
+        
+        // Then
+        XCTAssertEqual(expectedReadableError, readableError)
+    }
+    
 }

--- a/JustLog.podspec
+++ b/JustLog.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'JustLog'
-  s.version          = '3.1.3'
+  s.version          = '3.1.4'
   s.summary          = 'JustLog brings logging on iOS to the next level. It supports console, file and remote Logstash logging via TCP socket with no effort.'
 
   s.description      = "<<-DESC

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -217,21 +217,11 @@ extension Logger {
         if let error = error {
             let errorDictionaries = error.disassociatedErrorChain()
                 .map { errorDictionary(for: $0) }
-                .filter {
-                    guard JSONSerialization.isValidJSONObject($0) else {
-                        self.warning("Object { \($0) } is filtered out from the log", userInfo: ["Module": "JustLog"])
-                        return false
-                    }
-                    return true
-                }
+                .filter { JSONSerialization.isValidJSONObject($0) }
             retVal[errorsConst] = errorDictionaries
         }
         
-        guard let jsonString = retVal.toJSON() else {
-            self.warning("Log message '\(message)' can't be serialised", userInfo: ["Module": "JustLog"])
-            return ""
-        }
-        return jsonString
+        return retVal.toJSON() ?? ""
     }
     
     private func metadataDictionary(_ file: String, _ function: String, _ line: UInt) -> [String: Any] {

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -219,7 +219,7 @@ extension Logger {
                 .map { errorDictionary(for: $0) }
                 .filter {
                     guard JSONSerialization.isValidJSONObject($0) else {
-                        self.warning("Object { \($0) } is filted out from the log", userInfo: ["Module": "JustLog"])
+                        self.warning("Object { \($0) } is filtered out from the log", userInfo: ["Module": "JustLog"])
                         return false
                     }
                     return true

--- a/JustLog/Extensions/NSError+Readability.swift
+++ b/JustLog/Extensions/NSError+Readability.swift
@@ -28,9 +28,24 @@ extension NSError {
             case let error as NSError:
                 flattenedUserInfo[key] = error.humanReadableError()
             default:
-                continue
+                
+                if !JSONSerialization.isValidJSONObject(value) {
+                    var nonSerialisableObject: Any
+                    
+                    switch value {
+                    case let object as NSObject:
+                        nonSerialisableObject = object.description
+                    case let object as CustomStringConvertible:
+                        nonSerialisableObject = object.description
+                    default:
+                        nonSerialisableObject = "The value for key '\(key)' can't be serialised"
+                    }
+                    
+                    flattenedUserInfo[key] = nonSerialisableObject
+                }
             }
         }
+        
         return NSError(domain: domain, code: code, userInfo: flattenedUserInfo)
     }
 }


### PR DESCRIPTION
- Added JSON validation when Logger is trying converting `NSError` to readable object. If validation is failed we write `description` of the object which is failed. It will provide additional information about non-serialisable objects inside `userInfo`.