### PR TITLE
Tentative fix for concurrency issue

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - JustLog (3.2.1):
+  - JustLog (3.2.2):
     - SwiftyBeaver (~> 1.9.3)
   - SwiftyBeaver (1.9.3)
 
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  JustLog: 393c7c711e1099889b892bf847e3c513f0806d56
+  JustLog: 14808a5c7dc7098e53f52cbe107af3e000be2bbf
   SwiftyBeaver: 2e8acd6fc90c6d0a27055867a290794926d57c02
 
 PODFILE CHECKSUM: 0682bc8f039b3897a7cc797e15668481c16d38a1

--- a/JustLog.podspec
+++ b/JustLog.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'JustLog'
-  s.version          = '3.2.1'
+  s.version          = '3.2.2'
   s.summary          = 'JustLog brings logging on iOS to the next level. It supports console, file and remote Logstash logging via TCP socket with no effort.'
 
   s.description      = "<<-DESC

--- a/JustLog/Classes/LogstashDestination.swift
+++ b/JustLog/Classes/LogstashDestination.swift
@@ -45,6 +45,7 @@ public class LogstashDestination: BaseDestination  {
     public required init(socket: LogstashDestinationSocketProtocol, logActivity: Bool) {
         self.logDispatchQueue = OperationQueue()
         self.logDispatchQueue.maxConcurrentOperationCount = 1
+        self.logDispatchQueue.name = "com.justlog.logDispatchQueue"
         self.socket = socket
         super.init()
         self.logActivity = logActivity

--- a/JustLog/Classes/LogstashDestination.swift
+++ b/JustLog/Classes/LogstashDestination.swift
@@ -81,11 +81,12 @@ public class LogstashDestination: BaseDestination  {
         return nil
     }
 
-    public func forceSend(_ completionHandler: @escaping (_ error: Error?) -> Void  = {_ in }) {
-
-        self.completionHandler = completionHandler
-
-        writeLogs()
+    public func forceSend(_ completionHandler: @escaping (_ error: Error?) -> Void = {_ in }) {
+        logDispatchQueue.addOperation { [weak self] in
+            guard let self = self else { return }
+            self.completionHandler = completionHandler
+            self.writeLogs()
+        }
     }
     
     func writeLogs() {


### PR DESCRIPTION
This PR is a tentative fix for a concurrency issue.
Here the changes:
- sets a name on the operation queue to improve runtime inspection while debugging. The name should appear in the crash report too
- the completion handler is now accessed within the operation queue making it thread safe.