### PR TITLE
Put logs to the queue which are received before setting up Logger

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - JustLog (3.3.0):
+  - JustLog (3.4.0):
     - SwiftyBeaver (~> 1.9.3)
   - SwiftyBeaver (1.9.3)
 
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  JustLog: 51b4e9fa64eace58ef55b484cfaa07cc84aee5c1
+  JustLog: f8046f29f0e68969a3a4030177cced7053ccbf9d
   SwiftyBeaver: 2e8acd6fc90c6d0a27055867a290794926d57c02
 
 PODFILE CHECKSUM: 0682bc8f039b3897a7cc797e15668481c16d38a1

--- a/Example/Tests/LoggerTests.swift
+++ b/Example/Tests/LoggerTests.swift
@@ -13,7 +13,7 @@ class LoggerTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        _ = Logger.shared
+        Logger.shared.internalLogger.removeAllDestinations()
     }
     
     func test_errorDictionary_ReturnsDictionaryForError() {
@@ -28,7 +28,6 @@ class LoggerTests: XCTestCase {
         XCTAssertNotNil(dict["user_info"])
         XCTAssertNotNil(dict["error_code"])
         XCTAssertNotNil(dict["error_domain"])
-        
     }
     
     func test_errorDictionary_ReturnedDictionaryContainsUserInfo() {
@@ -47,8 +46,55 @@ class LoggerTests: XCTestCase {
         XCTAssertNotNil(dict["error_domain"])
     }
     
-//    func test_metadataDictionary_ReturnsDictionaryForMetadata() {
-//        let metadataDictionary = Logger.shared.metadataDictionary("thisFile.swift", "a function name", 33)
-//        XCTAssert
-//    }
+    func test_logger_whenSetupNotCompleted_thenLogsQueued() {
+        let sut = Logger.shared
+        sut.verbose("Verbose Message", error: nil, userInfo: nil, #file, #function, #line)
+        sut.debug("Debug Message", error: nil, userInfo: nil, #file, #function, #line)
+        sut.info("Info Message", error: nil, userInfo: nil, #file, #function, #line)
+        sut.warning("Warning Message", error: nil, userInfo: nil, #file, #function, #line)
+        sut.error("Error Message", error: nil, userInfo: nil, #file, #function, #line)
+        
+        XCTAssertFalse(sut.queuedLogs.isEmpty)
+        XCTAssertEqual(sut.queuedLogs.count, 5)
+        XCTAssertEqual(sut.queuedLogs[0].message, "Verbose Message")
+        XCTAssertEqual(sut.queuedLogs[1].message, "Debug Message")
+        XCTAssertEqual(sut.queuedLogs[2].message, "Info Message")
+        XCTAssertEqual(sut.queuedLogs[3].message, "Warning Message")
+        XCTAssertEqual(sut.queuedLogs[4].message, "Error Message")
+    }
+    
+    func test_logger_whenSetupCompleted_thenLogsNotQueued() {
+        let sut = Logger.shared
+        sut.setup()
+        
+        sut.verbose("Verbose Message", error: nil, userInfo: nil, #file, #function, #line)
+        sut.debug("Debug Message", error: nil, userInfo: nil, #file, #function, #line)
+        sut.info("Info Message", error: nil, userInfo: nil, #file, #function, #line)
+        sut.warning("Warning Message", error: nil, userInfo: nil, #file, #function, #line)
+        sut.error("Error Message", error: nil, userInfo: nil, #file, #function, #line)
+        
+        XCTAssertTrue(sut.queuedLogs.isEmpty)
+    }
+    
+    func test_logger_whenSetupCompletedAfterDelay_thenQueuedLogsSent() {
+        let sut = Logger.shared
+        
+        sut.verbose("Verbose Message", error: nil, userInfo: nil, #file, #function, #line)
+        sut.debug("Debug Message", error: nil, userInfo: nil, #file, #function, #line)
+        sut.info("Info Message", error: nil, userInfo: nil, #file, #function, #line)
+        sut.warning("Warning Message", error: nil, userInfo: nil, #file, #function, #line)
+        sut.error("Error Message", error: nil, userInfo: nil, #file, #function, #line)
+        
+        XCTAssertFalse(sut.queuedLogs.isEmpty)
+        XCTAssertEqual(sut.queuedLogs.count, 5)
+        XCTAssertEqual(sut.queuedLogs[0].message, "Verbose Message")
+        XCTAssertEqual(sut.queuedLogs[1].message, "Debug Message")
+        XCTAssertEqual(sut.queuedLogs[2].message, "Info Message")
+        XCTAssertEqual(sut.queuedLogs[3].message, "Warning Message")
+        XCTAssertEqual(sut.queuedLogs[4].message, "Error Message")
+        
+        sut.setup()
+        
+        XCTAssertTrue(sut.queuedLogs.isEmpty)
+    }
 }

--- a/JustLog.podspec
+++ b/JustLog.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'JustLog'
-  s.version          = '3.3.0'
+  s.version          = '3.4.0'
   s.summary          = 'JustLog brings logging on iOS to the next level. It supports console, file and remote Logstash logging via TCP socket with no effort.'
 
   s.description      = "<<-DESC


### PR DESCRIPTION
### Summary

- Add queue array for the logs which are received before `Logger` setup complete. And when `Logger` setup is finished all logs that array will be sent respectively
- Replace force unwrapping of `logstashHost` with empty string because this caused crash if client forget to call `setup` or `setupWithCustomLogSender(_:)` 
- Add unit tests
- Bump module version