### PR TITLE
Fix completion handler callback on force send and tentative crash fix

### DIFF
--- a/Example/Tests/LogstashDestinationTests.swift
+++ b/Example/Tests/LogstashDestinationTests.swift
@@ -43,8 +43,8 @@ class LogstashDestinationTests: XCTestCase {
     }
 
     func testCompletionHandlers() throws {
-        let expectFirstCompletion = expectation(description: "Send log first expectation")
-        let expectSecondCompletion = expectation(description: "Send log second expectation")
+        let expectation1 = expectation(description: "Send first log expectation")
+        let expectation2 = expectation(description: "Send second log expectation")
         let mockSocket = MockLogstashDestinationSocket(host: "", port: 0, timeout: 5, logActivity: true, allowUntrustedServer: true)
         let destination = LogstashDestination(socket: mockSocket, logActivity: true)
         _ = destination.send(.verbose, msg: "{}", thread: "", file: "", function: "", line: 0)
@@ -53,21 +53,21 @@ class LogstashDestinationTests: XCTestCase {
         _ = destination.send(.warning, msg: "{}", thread: "", file: "", function: "", line: 0)
         _ = destination.send(.error, msg: "{}", thread: "", file: "", function: "", line: 0)
         destination.forceSend { _ in
-            expectFirstCompletion.fulfill()
+            expectation1.fulfill()
         }
         destination.forceSend { _ in
-            expectSecondCompletion.fulfill()
+            expectation2.fulfill()
         }
         self.waitForExpectations(timeout: 10.0, handler: nil)
     }
 
     func testLoggingError() throws {
         let expect = expectation(description: "Error log expectation")
-        let expectFirstCompletion = expectation(description: "First completion expectation")
+        let expectation1 = expectation(description: "First completion expectation")
         let mockSocket = MockLogstashDestinationSocket(host: "", port: 0, timeout: 5, logActivity: true, allowUntrustedServer: true)
         mockSocket.errorState = true
         mockSocket.networkOperationCountExpectation = expect
-        mockSocket.completionHandlerCalledExpectation = expectFirstCompletion
+        mockSocket.completionHandlerCalledExpectation = expectation1
         let destination = LogstashDestination(socket: mockSocket, logActivity: true)
         _ = destination.send(.verbose, msg: "{}", thread: "", file: "", function: "", line: 0)
         _ = destination.send(.debug, msg: "{}", thread: "", file: "", function: "", line: 0)
@@ -80,20 +80,20 @@ class LogstashDestinationTests: XCTestCase {
         mockSocket.errorState = false
         let expect2 = expectation(description: "Send log expectation")
         expect2.expectedFulfillmentCount = 5
-        let expectSecondCompletion = expectation(description: "Second completion expectation")
+        let expectation2 = expectation(description: "Second completion expectation")
         mockSocket.networkOperationCountExpectation = expect2
-        mockSocket.completionHandlerCalledExpectation = expectSecondCompletion
+        mockSocket.completionHandlerCalledExpectation = expectation2
         destination.forceSend()
         self.waitForExpectations(timeout: 10.0, handler: nil)
     }
     
     func testLoggingCancel() throws {
         let expect = expectation(description: "Error log expectation")
-        let expectFirstCompletion = expectation(description: "First completion expectation")
+        let expectation1 = expectation(description: "First completion expectation")
         let mockSocket = MockLogstashDestinationSocket(host: "", port: 0, timeout: 5, logActivity: true, allowUntrustedServer: true)
         mockSocket.errorState = true
         mockSocket.networkOperationCountExpectation = expect
-        mockSocket.completionHandlerCalledExpectation = expectFirstCompletion
+        mockSocket.completionHandlerCalledExpectation = expectation1
         let destination = LogstashDestination(socket: mockSocket, logActivity: true)
         _ = destination.send(.verbose, msg: "{}", thread: "", file: "", function: "", line: 0)
         _ = destination.send(.debug, msg: "{}", thread: "", file: "", function: "", line: 0)
@@ -106,9 +106,9 @@ class LogstashDestinationTests: XCTestCase {
         destination.cancelSending()
         mockSocket.errorState = false
         let expect2 = expectation(description: "Send log expectation")
-        let expectSecondCompletion = expectation(description: "Second completion expectation")
+        let expectation2 = expectation(description: "Second completion expectation")
         mockSocket.networkOperationCountExpectation = expect2
-        mockSocket.completionHandlerCalledExpectation = expectSecondCompletion
+        mockSocket.completionHandlerCalledExpectation = expectation2
         _ = destination.send(.error, msg: "{}", thread: "", file: "", function: "", line: 0)
         destination.forceSend()
         self.waitForExpectations(timeout: 10.0, handler: nil)

--- a/Example/Tests/LogstashDestinationTests.swift
+++ b/Example/Tests/LogstashDestinationTests.swift
@@ -43,8 +43,8 @@ class LogstashDestinationTests: XCTestCase {
     }
 
     func testCompletionHandlers() throws {
-        let expect = expectation(description: "Send log expectation")
-        let expect2 = expectation(description: "Send log expectation2")
+        let expectFirstCompletion = expectation(description: "Send log first expectation")
+        let expectSecondCompletion = expectation(description: "Send log second expectation")
         let mockSocket = MockLogstashDestinationSocket(host: "", port: 0, timeout: 5, logActivity: true, allowUntrustedServer: true)
         let destination = LogstashDestination(socket: mockSocket, logActivity: true)
         _ = destination.send(.verbose, msg: "{}", thread: "", file: "", function: "", line: 0)
@@ -53,20 +53,21 @@ class LogstashDestinationTests: XCTestCase {
         _ = destination.send(.warning, msg: "{}", thread: "", file: "", function: "", line: 0)
         _ = destination.send(.error, msg: "{}", thread: "", file: "", function: "", line: 0)
         destination.forceSend { _ in
-            expect.fulfill()
+            expectFirstCompletion.fulfill()
         }
         destination.forceSend { _ in
-            expect2.fulfill()
+            expectSecondCompletion.fulfill()
         }
         self.waitForExpectations(timeout: 10.0, handler: nil)
     }
 
     func testLoggingError() throws {
         let expect = expectation(description: "Error log expectation")
+        let expectFirstCompletion = expectation(description: "First completion expectation")
         let mockSocket = MockLogstashDestinationSocket(host: "", port: 0, timeout: 5, logActivity: true, allowUntrustedServer: true)
         mockSocket.errorState = true
         mockSocket.networkOperationCountExpectation = expect
-        mockSocket.completionHandlerCalledExpectation = expectation(description: "completionHandlerCalledExpectation")
+        mockSocket.completionHandlerCalledExpectation = expectFirstCompletion
         let destination = LogstashDestination(socket: mockSocket, logActivity: true)
         _ = destination.send(.verbose, msg: "{}", thread: "", file: "", function: "", line: 0)
         _ = destination.send(.debug, msg: "{}", thread: "", file: "", function: "", line: 0)
@@ -79,18 +80,20 @@ class LogstashDestinationTests: XCTestCase {
         mockSocket.errorState = false
         let expect2 = expectation(description: "Send log expectation")
         expect2.expectedFulfillmentCount = 5
+        let expectSecondCompletion = expectation(description: "Second completion expectation")
         mockSocket.networkOperationCountExpectation = expect2
-        mockSocket.completionHandlerCalledExpectation = expectation(description: "completionHandlerCalledExpectation")
+        mockSocket.completionHandlerCalledExpectation = expectSecondCompletion
         destination.forceSend()
         self.waitForExpectations(timeout: 10.0, handler: nil)
     }
     
     func testLoggingCancel() throws {
         let expect = expectation(description: "Error log expectation")
+        let expectFirstCompletion = expectation(description: "First completion expectation")
         let mockSocket = MockLogstashDestinationSocket(host: "", port: 0, timeout: 5, logActivity: true, allowUntrustedServer: true)
         mockSocket.errorState = true
         mockSocket.networkOperationCountExpectation = expect
-        mockSocket.completionHandlerCalledExpectation = expectation(description: "completionHandlerCalledExpectation")
+        mockSocket.completionHandlerCalledExpectation = expectFirstCompletion
         let destination = LogstashDestination(socket: mockSocket, logActivity: true)
         _ = destination.send(.verbose, msg: "{}", thread: "", file: "", function: "", line: 0)
         _ = destination.send(.debug, msg: "{}", thread: "", file: "", function: "", line: 0)
@@ -103,8 +106,9 @@ class LogstashDestinationTests: XCTestCase {
         destination.cancelSending()
         mockSocket.errorState = false
         let expect2 = expectation(description: "Send log expectation")
+        let expectSecondCompletion = expectation(description: "Second completion expectation")
         mockSocket.networkOperationCountExpectation = expect2
-        mockSocket.completionHandlerCalledExpectation = expectation(description: "completionHandlerCalledExpectation")
+        mockSocket.completionHandlerCalledExpectation = expectSecondCompletion
         _ = destination.send(.error, msg: "{}", thread: "", file: "", function: "", line: 0)
         destination.forceSend()
         self.waitForExpectations(timeout: 10.0, handler: nil)

--- a/JustLog/Classes/LogstashDestination.swift
+++ b/JustLog/Classes/LogstashDestination.swift
@@ -18,7 +18,7 @@ typealias LogTag = Int
 /// Here's a brief summary of what operations are added to the queue and when:
 /// A log is generated via `send` and added to the `logsToShip` dictionary (along with a `tag` identifier).
 /// At some point `writeLogs` is called that creates an `NSURLSessionStreamTask` to send the log to the server.
-/// When the writer finish all streams operation it calls the completion handler passing the logs that failed to push.
+/// Once the writer has completed all operations, it calls the completion handler passing the logs that failed to push.
 /// Those logs are added back to `logsToShip`
 /// An optional `completionHandler` is called when all logs existing before the `forceSend` call have been tried to send once.
 public class LogstashDestination: BaseDestination  {

--- a/JustLog/Classes/LogstashDestination.swift
+++ b/JustLog/Classes/LogstashDestination.swift
@@ -9,33 +9,33 @@
 import Foundation
 import SwiftyBeaver
 
-/// This entire class relies on `logDispatchQueue` to synchronise access to the `logsToShip` dictionary
-/// Every action is put in the `logDispatchQueue` which is synchronous, even though the actual sending
-/// via `URLSession` is not.
+typealias LogContent = [String: Any]
+typealias LogTag = Int
+
+/// This entire class relies on `operationQueue` to synchronise access to the `logsToShip` dictionary
+/// Every action is put in the `operationQueue` which is synchronous, even though the actual sending
+/// via `URLSession` is not. The writers' completion handler are executed on the underlying queue of the `OperationQueue`
 /// Here's a brief summary of what operations are added to the queue and when:
 /// A log is generated via `send` and added to the `logsToShip` dictionary (along with a `tag` identifier).
 /// At some point `writeLogs` is called that creates an `NSURLSessionStreamTask` to send the log to the server.
-/// When the task completes, either `completeLog` or `retryLog` are called.
-///    `completeLog` removes the log from `logsToShip`
-///    `retryLog` clears the log from `logsInSocketQueue` and causes it to be resent the next time `writeLogs` is called.
-/// An optional `completionHandler` is called when all logs are written.
+/// When the writer finish all streams operation it calls the completion handler passing the logs that failed to push.
+/// Those logs are added back to `logsToShip`
+/// An optional `completionHandler` is called when all logs existing before the `forceSend` call have been tried to send once.
 public class LogstashDestination: BaseDestination  {
     
     /// Settings
-    var logActivity: Bool = false
+    var shouldLogActivity: Bool = false
     public var logzioToken: String?
     
     /// Logs buffer
-    private var logsToShip = [Int : [String : Any]]()
-    private let logDispatchQueue: OperationQueue
-    
+    private var logsToShip = [LogTag: LogContent]()
+    private let operationQueue: OperationQueue
+    private let dispatchQueue = DispatchQueue(label: "com.justlog.LogstashDestination.dispatchQueue", qos: .utility)
     /// Private
-    private var completionHandler: ((_ error: Error?) -> Void)?
     private let logzioTokenKey = "token"
     
     /// Socket
     private let socket: LogstashDestinationSocketProtocol
-    private var logsInSocketQueue = [Int]()
     
     @available(*, unavailable)
     override init() {
@@ -43,12 +43,13 @@ public class LogstashDestination: BaseDestination  {
     }
     
     public required init(socket: LogstashDestinationSocketProtocol, logActivity: Bool) {
-        self.logDispatchQueue = OperationQueue()
-        self.logDispatchQueue.maxConcurrentOperationCount = 1
-        self.logDispatchQueue.name = "com.justlog.logDispatchQueue"
+        self.operationQueue = OperationQueue()
+        self.operationQueue.underlyingQueue = dispatchQueue
+        self.operationQueue.maxConcurrentOperationCount = 1
+        self.operationQueue.name = "com.justlog.LogstashDestination.operationQueue"
         self.socket = socket
         super.init()
-        self.logActivity = logActivity
+        self.shouldLogActivity = logActivity
     }
     
     deinit {
@@ -56,19 +57,23 @@ public class LogstashDestination: BaseDestination  {
     }
     
     public func cancelSending() {
-        self.logDispatchQueue.cancelAllOperations()
-        self.logDispatchQueue.addOperation { [weak self] in
+        self.operationQueue.cancelAllOperations()
+        self.operationQueue.addOperation { [weak self] in
             guard let self = self else { return }
-            self.logsToShip = [Int : [String : Any]]()
+            self.logsToShip = [LogTag: LogContent]()
         }
-        self.logsInSocketQueue = [Int]()
         self.socket.cancel()
     }
     
     // MARK: - Log dispatching
 
-    override public func send(_ level: SwiftyBeaver.Level, msg: String, thread: String, file: String,
-                              function: String, line: Int, context: Any? = nil) -> String? {
+    override public func send(_ level: SwiftyBeaver.Level,
+                              msg: String,
+                              thread: String,
+                              file: String,
+                              function: String,
+                              line: Int,
+                              context: Any? = nil) -> String? {
         
         if let dict = msg.toDictionary() {
             var flattened = dict.flattened()
@@ -81,127 +86,42 @@ public class LogstashDestination: BaseDestination  {
         return nil
     }
 
-    public func forceSend(_ completionHandler: @escaping (_ error: Error?) -> Void = {_ in }) {
-        logDispatchQueue.addOperation { [weak self] in
-            guard let self = self else { return }
-            self.completionHandler = completionHandler
-            self.writeLogs()
-        }
-    }
-    
-    func writeLogs() {
-        
-        self.logDispatchQueue.addOperation{ [weak self] in
-            
+    private func addLog(_ dict: LogContent) {
+        operationQueue.addOperation { [weak self] in
             guard let self = self else { return }
             
-            let pendingLogs = Set(self.logsInSocketQueue)
-            let unprocessedLogs = self.logsToShip.filter({ (tag: Int, _) -> Bool in
-                !pendingLogs.contains(where: { $0 == tag })
-            })
-            guard !unprocessedLogs.isEmpty else {
-                if self.logActivity {
-                    print("writeLogs() - nothing to write, \(pendingLogs.count) in URLSession queue")
-                }
-                return
-            }
-            self.socket.sendLogs(unprocessedLogs,
-                                 transform: self.dataToShip,
-                                 enqueued: { self.logsInSocketQueue.append($0) }) { (tag, error) in
-                if let error = error {
-                    if self.logActivity {
-                        print("🔌 <LogstashDestination>, \(tag) did error: \(error.localizedDescription)")
-                    }
-                    self.retryLog(withTag: tag)
-                    self.callCompleteHandlerIfRequired(optionalError: error)
-                } else {
-                    if self.logActivity {
-                        print("🔌 <LogstashDestination>, did write \(tag)")
-                    }
-                    self.completeLog(withTag:tag)
-                    self.callCompleteHandlerIfRequired()
-                }
-            }
-        }
-    }
-    
-    func addLog(_ dict: [String: Any]) {
-        logDispatchQueue.addOperation { [weak self] in
             let time = mach_absolute_time()
             let logTag = Int(truncatingIfNeeded: time)
-            self?.logsToShip[logTag] = dict
+            self.logsToShip[logTag] = dict
         }
     }
-    
-    func dataToShip(_ dict: [String: Any]) -> Data {
-        
-        var data = Data()
-        
-        do {
-            data = try JSONSerialization.data(withJSONObject:dict, options:[])
-            
-            if let encodedData = "\n".data(using: String.Encoding.utf8) {
-                data.append(encodedData)
-            }
-        } catch {
-            print(error.localizedDescription)
-        }
-        
-        return data
-    }
-    
-    func completeLog(withTag tag: Int) {
-        
-        self.logDispatchQueue.addOperation{ [weak self] in
+
+    public func forceSend(_ completionHandler: @escaping (_ error: Error?) -> Void = {_ in }) {
+        operationQueue.addOperation { [weak self] in
             guard let self = self else { return }
-            assert(!self.logsInSocketQueue.isEmpty, "Completed a session without any tasks scheduled!")
-            
-            // get the tag for this task & remove from queue
-            if self.logsInSocketQueue.contains(tag) {
-                self.logsInSocketQueue.removeAll(where: { $0 == tag })
-                self.logsToShip[tag] = nil
-            } else {
-                if self.logActivity {
-                    print("🔌 <LogstashDestination>, Completed task for tag (\(tag)")
-                }
-            }
-            
-            if self.logActivity {
-                print("🔌 <LogstashDestination>, \(self.logsInSocketQueue.count) remaining tasks")
-            }
-        }
-    }
-    
-    func retryLog(withTag tag: Int) {
-        
-        self.logDispatchQueue.addOperation{ [weak self] in
-            guard let self = self else { return }
-            
-            // get the tag for this task & remove from queue
-            if self.logsInSocketQueue.contains(tag) {
-                self.logsInSocketQueue.removeAll(where: { $0 == tag })
-            }
-            
-            if self.logActivity {
-                print("🔌 <LogstashDestination>, \(self.logsInSocketQueue.count) remaining tasks")
-            }
-        }
-    }
-    
-    func callCompleteHandlerIfRequired(optionalError error: Error? = nil) {
-        
-        self.logDispatchQueue.addOperation { [weak self] in
-            guard let self = self else { return }
-            
-            if self.logsInSocketQueue.isEmpty {
-                if let completionHandler = self.completionHandler {
-                    if self.logActivity {
-                        print("🔌 <LogstashDestination>, calling completion handler")
-                    }
+            let writer = LogstashDestinationWriter(socket: self.socket, shouldLogActivity: self.shouldLogActivity)
+            let logsBatch = self.logsToShip
+            self.logsToShip = [LogTag: LogContent]()
+            writer.write(logs: logsBatch, queue: self.dispatchQueue) { [weak self] missing, error in
+                guard let self = self else {
                     completionHandler(error)
+                    return
                 }
-                self.completionHandler = nil
+                
+                if let unsent = missing {
+                    self.logsToShip.merge(unsent) { lhs, rhs in lhs }
+                    self.printActivity("🔌 <LogstashDestination>, \(unsent.count) failed tasks")
+                }
+                completionHandler(error)
             }
         }
+    }
+}
+
+extension LogstashDestination {
+    
+    private func printActivity(_ string: String) {
+        guard shouldLogActivity else { return }
+        print(string)
     }
 }

--- a/JustLog/Classes/LogstashDestinationWriter.swift
+++ b/JustLog/Classes/LogstashDestinationWriter.swift
@@ -1,0 +1,67 @@
+//
+//  LogstashDestinationWriter.swift
+//  JustLog
+//
+//  Created by Luigi Parpinel on 25/05/21.
+//
+
+import Foundation
+
+class LogstashDestinationWriter {
+
+    private let socket: LogstashDestinationSocketProtocol
+
+    private let shouldLogActivity: Bool
+    
+    init(socket: LogstashDestinationSocketProtocol, shouldLogActivity: Bool) {
+        self.socket = socket
+        self.shouldLogActivity = shouldLogActivity
+    }
+    
+    func write(logs: [LogTag: LogContent],
+               queue: DispatchQueue,
+               completionHandler: @escaping ([LogTag: LogContent]?, Error?) -> Void) {
+        
+        guard !logs.isEmpty else {
+            Self.printActivity("writeLogs() - nothing to write", shouldLogActivity: self.shouldLogActivity)
+            completionHandler(nil, nil)
+            return
+        }
+
+        let shouldLogActivity = self.shouldLogActivity
+        socket.sendLogs(logs, transform: transformLogToData, queue: queue) { status in
+            let unsentLog = logs.filter { status.keys.contains($0.key) }
+            if unsentLog.isEmpty {
+                Self.printActivity("🔌 <LogstashDestination>, did write tags: \(logs.keys)", shouldLogActivity: shouldLogActivity)
+                completionHandler(nil, nil)
+                return
+            }
+            
+            if shouldLogActivity {
+                status.forEach {
+                    Self.printActivity("🔌 <LogstashDestination>, \($0.key) did error: \($0.value.localizedDescription)", shouldLogActivity: shouldLogActivity)
+                }
+            }
+            
+            completionHandler(unsentLog, status.first?.value)
+        }
+    }
+    
+    private func transformLogToData(_ dict: LogContent) -> Data {
+        do {
+            var data = try JSONSerialization.data(withJSONObject:dict, options:[])
+            if let encodedData = "\n".data(using: String.Encoding.utf8) {
+                data.append(encodedData)
+            }
+            return data
+        } catch {
+            Self.printActivity(error.localizedDescription, shouldLogActivity: self.shouldLogActivity)
+            return Data()
+        }
+    }
+
+    private static func printActivity(_ string: String, shouldLogActivity: Bool) {
+        guard shouldLogActivity else { return }
+        print(string)
+    }
+}


### PR DESCRIPTION
This PR fixes an issue that was preventing the completion handler to be called if `forceSend` was called before the end of the previous batch send.
By rewriting the callback logic this PR tries also to address a crash related to over-released objects.