### PR TITLE
Made sanitize property thread safe.

### DIFF
--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -23,8 +23,6 @@ jobs:
         bundler-cache: true
     - name: Run pod install
       run: bundle exec pod install --project-directory=Example
-    - name: Add SSH key
-      run: ssh-add - <<< "${{ secrets.SSH_KEY }}"
     - name: Allow SSH fingerprinting
       run: |
         sudo defaults write com.apple.dt.Xcode IDEPackageSupportUseBuiltinSCM YES

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - JustLog (3.7.0):
+  - JustLog (3.7.1):
     - SwiftyBeaver (~> 1.9.3)
   - SwiftyBeaver (1.9.5)
 
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  JustLog: d6357f60a31792157b98ef0eb88f73061aae7ccc
+  JustLog: 5889c708affff45c906d38a32f352330a52296c3
   SwiftyBeaver: 84069991dd5dca07d7069100985badaca7f0ce82
 
 PODFILE CHECKSUM: c7680d001abb03143de15e13f1b6fbabb258d898

--- a/JustLog.podspec
+++ b/JustLog.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'JustLog'
-  s.version          = '3.7.0'
+  s.version          = '3.7.1'
   s.summary          = 'JustLog brings logging on iOS to the next level. It supports console, file and remote Logstash logging via TCP socket with no effort.'
 
   s.description      = "<<-DESC

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -28,9 +28,29 @@ public final class Logger: NSObject {
         let line: UInt
     }
     
-    public var sanitize: (_ message: String, _ minimumLogType: LogType) -> String = { message, minimumLogType in
+    public typealias SanitizeClosureType = (_ message: String, _ minimumLogType: LogType) -> String
+    private var _sanitize: SanitizeClosureType = { message, minimumLogType in
         
         return message
+    }
+    private let sanitizePropertyQueue = DispatchQueue(label: "com.justeat.justlog.sanitizePropertyQueue", qos: .default, attributes: .concurrent)
+    public var sanitize: SanitizeClosureType {
+        get {
+            var sanitizeClosure: SanitizeClosureType? = nil
+            sanitizePropertyQueue.sync {
+                sanitizeClosure = _sanitize
+            }
+            if let sanitizeClosure = sanitizeClosure {
+                return sanitizeClosure
+            } else {
+                fatalError("Sanitization closure not set")
+            }
+        }
+        set {
+            sanitizePropertyQueue.async(flags: .barrier) {
+                self._sanitize = newValue
+            }
+        }
     }
     
     public var logTypeKey = "log_type"

--- a/JustLog/Classes/Logger.swift
+++ b/JustLog/Classes/Logger.swift
@@ -43,7 +43,10 @@ public final class Logger: NSObject {
             if let sanitizeClosure = sanitizeClosure {
                 return sanitizeClosure
             } else {
-                fatalError("Sanitization closure not set")
+                assertionFailure("Sanitization closure not set")
+                return { message, _ in
+                    return message
+                }
             }
         }
         set {


### PR DESCRIPTION
## Description
Made sanitize property thread safe. So that it can now be safely while the logger is running.

## Motivation and Context
Clients need to be able to update their log sanitization rules at run time. While this was technically possible, the sanitize property can potentially be called from multiple threads (via the static singleton).

## How Has This Been Tested?
Tested via the example app and existing unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
