### PR TITLE
Fix stream task completion handler callback

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - JustLog (3.7.1):
+  - JustLog (3.7.2):
     - SwiftyBeaver (~> 1.9.3)
   - SwiftyBeaver (1.9.5)
 
@@ -7,7 +7,7 @@ DEPENDENCIES:
   - JustLog (from `../`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - SwiftyBeaver
 
 EXTERNAL SOURCES:
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  JustLog: 5889c708affff45c906d38a32f352330a52296c3
+  JustLog: db54ca372b659e3da001d24f6e3c701ed552d87e
   SwiftyBeaver: 84069991dd5dca07d7069100985badaca7f0ce82
 
 PODFILE CHECKSUM: c7680d001abb03143de15e13f1b6fbabb258d898

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,6 +266,7 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
+  ruby
   x86_64-darwin-18
   x86_64-darwin-19
   x86_64-darwin-20

--- a/JustLog.podspec
+++ b/JustLog.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'JustLog'
-  s.version          = '3.7.1'
+  s.version          = '3.7.2'
   s.summary          = 'JustLog brings logging on iOS to the next level. It supports console, file and remote Logstash logging via TCP socket with no effort.'
 
   s.description      = "<<-DESC

--- a/JustLog/Classes/LogstashDestinationSocket.swift
+++ b/JustLog/Classes/LogstashDestinationSocket.swift
@@ -87,12 +87,17 @@ class LogstashDestinationSocket: NSObject, LogstashDestinationSocketProtocol {
                 let tag = log.0
                 let logData = transform(log.1)
                 dispatchGroup.enter()
-                task.write(logData, timeout: self.timeout) { error in
+                task.write(logData, timeout: self.timeout) { [weak self] error in
+                    guard let self = self else {
+                        dispatchGroup.leave()
+                        return
+                    }
+
                     self.dispatchQueue.async {
                         if let error = error {
                             sendStatus[tag] = error
                         }
-                        
+
                         dispatchGroup.leave()
                     }
                 }


### PR DESCRIPTION
## Description
This PR fixes a crash which happens in the stream task completion handler. I think, there might be a rare situation when `self` is `nil` and as result the handler closure might make a crash.

## Screenshots (if appropriate):
There is a stack trace of the crash

<img width="1228" alt="Screenshot 2021-10-04 at 12 41 54" src="https://user-images.githubusercontent.com/3673877/135829468-34db19f6-b9df-4d57-a3f6-47e20f038769.png">