### PR TITLE
Add publish-to-trunk-workflow.yml

### DIFF
--- a/.github/workflows/publish-to-trunk-workflow.yml
+++ b/.github/workflows/publish-to-trunk-workflow.yml
@@ -1,0 +1,20 @@
+name: Publish to Trunk
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Cocoapods
+      run: gem install cocoapods
+    - name: Deploy to Cocoapods
+      run: |
+        set -eo pipefail
+        export LIB_VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
+        pod lib lint --allow-warnings
+        pod trunk push --allow-warnings
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -2,7 +2,7 @@ name: Pull Request Workflow
 on: [pull_request]
 jobs:
   run-tests:
-    runs-on: macos-11
+    runs-on: macOS-latest
     timeout-minutes: 15
     steps:
     - name: Cancel previous jobs
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '13.2.1'
+        xcode-version: '13.3.1'
     - name: Setup ruby and bundler dependencies
       uses: ruby/setup-ruby@v1.81.0
       with:

--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '13.3.1'
+        xcode-version: '13.2.1'
     - name: Setup ruby and bundler dependencies
       uses: ruby/setup-ruby@v1.81.0
       with:

--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -12,18 +12,25 @@ jobs:
     - name: Git checkout
       uses: actions/checkout@v2.3.4
       with:
+        fetch-depth: 0
         ref: ${{ github.ref }}
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '13.2.1'
+        xcode-version: latest-stable
     - name: Setup ruby and bundler dependencies
       uses: ruby/setup-ruby@v1.81.0
       with:
         bundler-cache: true
     - name: Run pod install
-      run: bundle exec pod install --project-directory=Example
+      run: |
+        set -eo pipefail
+        export LIB_VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
+        bundle exec pod install --project-directory=Example
     - name: Run tests
       run: bundle exec fastlane unit_tests device:'iPhone 11'
     - name: Validate lib
-      run: bundle exec pod lib lint --allow-warnings
+      run: |
+        set -eo pipefail
+        export LIB_VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
+        bundle exec pod lib lint --allow-warnings

--- a/JustLog.podspec
+++ b/JustLog.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'JustLog'
-  s.version          = '4.0.0'
+  s.version          = ENV['LIB_VERSION']
   s.summary          = 'JustLog brings logging on iOS to the next level. It supports console, file and remote Logstash logging via TCP socket with no effort.'
 
   s.description      = "<<-DESC


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Automate the process of publishing a podspec to Trunk via a GitHub Actions workflow.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to automate the publishing of podspecs to Trunk.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Due to the nature of this change, this cannot be tested until the workflow is triggered by GitHub Actions.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Workflow change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
