### PR TITLE
Fix unbalanced dispatch leave crash

### DIFF
--- a/JustLog/Classes/LogstashDestinationSocket.swift
+++ b/JustLog/Classes/LogstashDestinationSocket.swift
@@ -103,7 +103,9 @@ class LogstashDestinationSocket: NSObject, LogstashDestinationSocketProtocol {
             task.resume()
 
             dispatchGroup.notify(queue: queue) {
-                task.cancel()
+                task.closeRead()
+                task.closeWrite()
+
                 complete(sendStatus)
             }
         }

--- a/JustLog/Classes/LogstashDestinationSocket.swift
+++ b/JustLog/Classes/LogstashDestinationSocket.swift
@@ -93,12 +93,10 @@ class LogstashDestinationSocket: NSObject, LogstashDestinationSocketProtocol {
                         return
                     }
 
-                    self.dispatchQueue.async {
+                    self.dispatchQueue.async(group: dispatchGroup) {
                         if let error = error {
                             sendStatus[tag] = error
                         }
-
-                        dispatchGroup.leave()
                     }
                 }
             }


### PR DESCRIPTION
Changes the approach to leaving a dispatch group in an async call

## Description
This change removes the explicit call to `dispatchGroup.leave()` and instead passes the group in to the `dispatchQueue.async` method. In my testing this fixes the random unbalanced crash that I would experience on my app.

Additionally I made a change from the previous fix, modifying `task.cancel` in the `dispatchGroup.notify` to instead call `task.closeRead` and `task.closeWrite`. Both approaches have the same outcome, but I feared that the cancel might have unintended side effects.

## Motivation and Context
Solves the issue mentioned in #110 

## How Has This Been Tested?
In running my app and this library with wifi turned off, I would experience a crash sometime between 1 and 10 minutes of running. After applying this patch I was initially able to run my app for about 30 minutes, after which I restarted to do a fresh test and it ran for 15 and a half hours. I restarted it again for a third fresh test and it's been running for nearly an hour without any crashes.

## Screenshots (if appropriate):
<img width="851" alt=" " src="https://user-images.githubusercontent.com/321477/171676619-3c1dce33-1d25-48e3-884c-0aa035aa090a.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
