### PR TITLE
Fix dispatch group leave in LogstashDestinationSocket

### DIFF
--- a/JustLog/Classes/LogstashDestinationSocket.swift
+++ b/JustLog/Classes/LogstashDestinationSocket.swift
@@ -93,10 +93,12 @@ class LogstashDestinationSocket: NSObject, LogstashDestinationSocketProtocol {
                         return
                     }
 
-                    self.dispatchQueue.async(group: dispatchGroup) {
+                    self.dispatchQueue.async {
                         if let error = error {
                             sendStatus[tag] = error
                         }
+
+                        dispatchGroup.leave()
                     }
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
`LogstashDestinationSocket` never calls the `complete` block in the `LogstashDestinationSocket.sendLogs(_:transform:queue:complete:)` function. After debugging, I found the issue was related to never leaving the `DispatchGroup` it uses to manage the completion. 

## Description
While debugging logs not displaying in our server end (which was related to something else), I found that `LogstashDestinationSocket` (and therefore also `LogstashDestinationWriter`, and therefore `LogstashDestination`) never calls the completion block. This PR fixes it by correctly managing the `DispatchGroup` that caused the bug.

## Motivation and Context

After investigating, I noticed the following issue in the lines below:

```swift
    let dispatchGroup = DispatchGroup()
    for log in logs.sorted(by: { $0.0 < $1.0 }) {
        // get the log
        dispatchGroup.enter()
        task.write(logData, timeout: self.timeout) { [weak self] error in
        guard let self = self else {
            dispatchGroup.leave()
            return
        }

    self.dispatchQueue.async(group: dispatchGroup) {
        if let error = error {
            sendStatus[tag] = error
        }
    }
```

According to the [docs](https://developer.apple.com/documentation/dispatch/dispatchgroup/1452872-leave), `leave()` needs to have balanced calls with `enter()`. Although enter is called, `leave()` is only called in the `guard` branch, and the regular flow continues to using the dispatch queue. However, here's the thing. Associating a dispatch group with the [`DispatchQueue.async(group:qos:flags:execute:)`](https://developer.apple.com/documentation/dispatch/1453084-dispatch_group_async) method, takes care of both entering and leaving a group **automatically**. So, in this case, the group receives 2 enter calls (one manual, one automatic), and only one leave call (automatic).

You can confirm this behavior in this [SwiftFiddle](https://swiftfiddle.com/abfw3vuwljcnrhbx43wa2fs5ve).

There are a number of ways to fix this, but I found the simplest one is omitting the group in the `async` call, and manually calling `leave()` in the end.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Although there are tests in `LogstashDestinationTests`, they use `MockLogstashDestinationSocket`, so they don't cover this issue. There would need to be tests specific to  `LogstashDestinationSocket`.

I tested the completion block behavior before and after the changes, confirming the issue and the fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
